### PR TITLE
Add the 'bind_address' configuration key.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,7 @@
 static const statsite_config DEFAULT_CONFIG = {
     8125,               // TCP defaults to 8125
     8125,               // UDP on 8125
+    "0.0.0.0",          // Listen on all IPv4 addresses
     "DEBUG",            // DEBUG level
     LOG_DEBUG,
     0.01,               // Default 1% error
@@ -129,6 +130,8 @@ static int config_callback(void* user, const char* section, const char* name, co
         config->pid_file = strdup(value);
     } else if (NAME_MATCH("input_counter")) {
         config->input_counter = strdup(value);
+    } else if (NAME_MATCH("bind_address")) {
+        config->bind_address = strdup(value);
 
     // Unknown parameter?
     } else {

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,7 @@
 typedef struct {
     int tcp_port;
     int udp_port;
+    char *bind_address;
     char *log_level;
     int syslog_log_level;
     double timer_eps;

--- a/src/networking.c
+++ b/src/networking.c
@@ -188,10 +188,18 @@ static int circbuf_write(circular_buffer *buf, char *in, uint64_t bytes);
  */
 static int setup_tcp_listener(statsite_networking *netconf) {
     struct sockaddr_in addr;
+    struct in_addr bind_addr;
     bzero(&addr, sizeof(addr));
+    bzero(&bind_addr, sizeof(bind_addr));
     addr.sin_family = PF_INET;
     addr.sin_port = htons(netconf->config->tcp_port);
-    addr.sin_addr.s_addr = INADDR_ANY;
+
+    int ret = inet_pton(AF_INET, netconf->config->bind_address, &bind_addr);
+    if (ret != 1) {
+        syslog(LOG_ERR, "Invalid IPv4 address '%s'!", netconf->config->bind_address);
+        return 1;
+    }
+    addr.sin_addr = bind_addr;
 
     // Make the socket, bind and listen
     int tcp_listener_fd = socket(PF_INET, SOCK_STREAM, 0);
@@ -227,10 +235,18 @@ static int setup_tcp_listener(statsite_networking *netconf) {
  */
 static int setup_udp_listener(statsite_networking *netconf) {
     struct sockaddr_in addr;
+    struct in_addr bind_addr;
     bzero(&addr, sizeof(addr));
+    bzero(&bind_addr, sizeof(bind_addr));
     addr.sin_family = PF_INET;
     addr.sin_port = htons(netconf->config->udp_port);
-    addr.sin_addr.s_addr = INADDR_ANY;
+
+    int ret = inet_pton(AF_INET, netconf->config->bind_address, &bind_addr);
+    if (ret != 1) {
+        syslog(LOG_ERR, "Invalid IPv4 address '%s'!", netconf->config->bind_address);
+        return 1;
+    }
+    addr.sin_addr = bind_addr;
 
     // Make the socket, bind and listen
     int udp_listener_fd = socket(PF_INET, SOCK_DGRAM, 0);
@@ -309,6 +325,10 @@ int init_networking(statsite_config *config, statsite_networking **netconf_out) 
         free(netconf);
         return 1;
     }
+
+    syslog(LOG_INFO, "Listening on tcp '%s:%d' udp '%s:%d'.",
+           netconf->config->bind_address, netconf->config->tcp_port,
+           netconf->config->bind_address, netconf->config->udp_port);
 
     // Setup the async handler
     ev_async_init(&netconf->loop_async, handle_async_event);


### PR DESCRIPTION
Hello and thank you for statsite!

This pull requests adds really basic support for setting the daemon's bind address. Tests included. Also added an extra INFO log line:

```
statsite[4309]: Starting statsite.
statsite[4309]: Listening on tcp '0.0.0.0:8125' udp '0.0.0.0:8125'.
```

That's about it.
