### PR TITLE
A quick hack to support no prefix (emtpy)

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -44,7 +44,11 @@ class GraphiteStore(object):
         # Construct the output
         metrics = [m.split("|") for m in metrics if m]
         self.logger.info("Outputting %d metrics" % len(metrics))
-        data = "\n".join(["%s.%s %s %s" % (self.prefix, k, v, ts) for k, v, ts in metrics]) + "\n"
+        if not self.prefix:
+            lines = ["%s %s %s" % (k, v, ts) for k, v, ts in metrics]
+        else:
+            lines = ["%s.%s %s %s" % (self.prefix, k, v, ts) for k, v, ts in metrics]
+        data = "\n".join(lines) + "\n"
 
         # Serialize writes to the socket
         try:
@@ -91,4 +95,3 @@ if __name__ == "__main__":
     # Flush
     graphite.flush(metrics.split("\n"))
     graphite.close()
-


### PR DESCRIPTION
Trying to keep it backwards compatible.

stream_cmd = python sinks/graphite.py localhost 2003 ''"
