### PR TITLE
dup2 STD*_FILE instead close to avoid SIGPIPE under linux

### DIFF
--- a/src/statsite.c
+++ b/src/statsite.c
@@ -6,6 +6,7 @@
  * front ends.
  */
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
@@ -160,6 +161,7 @@ int main(int argc, char **argv) {
     // Daemonize
     if (config->daemonize) {
         pid_t pid, sid;
+        int fd;
         syslog(LOG_INFO, "Daemonizing.");
         pid = fork();
 
@@ -185,9 +187,12 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        close(STDIN_FILENO);
-        close(STDOUT_FILENO);
-        close(STDERR_FILENO);
+        if ((fd = open("/dev/null", O_RDWR, 0)) != -1) {
+          dup2(fd, STDIN_FILENO);
+          dup2(fd, STDOUT_FILENO);
+          dup2(fd, STDERR_FILENO);
+          if (fd > STDERR_FILENO) close(fd);
+        }
     }
 
     // Log that we are starting up


### PR DESCRIPTION
before the change:

close(0)                                = 0
close(1)                                = 0
close(2)                                = 0
time([1368105310])                      = 1368105310
writev(2, [{"statsite[12760]: Starting statsi"..., 35}, {"\n", 1}], 2) = -1 EBADF (Bad file descriptor)
sendto(3, "<134>May  9 21:15:10 statsite[12"..., 56, MSG_NOSIGNAL, NULL, 0) = 56
getuid()                                = 0
geteuid()                               = 0
getgid()                                = 0
getegid()                               = 0
epoll_create1(O_CLOEXEC)                = 0
fcntl(0, F_SETFD, FD_CLOEXEC)           = 0
eventfd2(0, O_NONBLOCK|O_CLOEXEC)       = 1
fcntl(1, F_SETFD, FD_CLOEXEC)           = 0
fcntl(1, F_SETFL, O_RDONLY|O_NONBLOCK)  = 0
rt_sigaction(SIGCHLD, {0x408310, ~[RTMIN RT_1], SA_RESTORER|SA_RESTART, 0x7fc0d723f030}, NULL, 8) = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 2
setsockopt(2, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
bind(2, {sa_family=AF_INET, sin_port=htons(8125), sin_addr=inet_addr("0.0.0.0")}, 16) = -1 EADDRINUSE (Address already in use)
time([1368105310])                      = 1368105310
writev(2, [{"statsite[12760]: Failed to bind "..., 74}, {"\n", 1}], 2) = -1 EPIPE (Broken pipe)
--- SIGPIPE (Broken pipe) @ 0 (0) ---
