### PR TITLE
Building statsite with older gcc (4.1.2) fails with "dereferencing type-punned pointer will break strict-aliasing rules"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,7 +6,7 @@ murmur = envmurmur.Library('murmur', Glob("deps/murmurhash/*.cpp"))
 envinih = Environment(CPATH = ['deps/inih/'], CFLAGS="-O3")
 inih = envinih.Library('inih', Glob("deps/inih/*.c"))
 
-env_statsite_with_err = Environment(CCFLAGS = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3 -pthread -Ideps/inih/ -Ideps/libev/ -Isrc/')
+env_statsite_with_err = Environment(CCFLAGS = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -Wstrict-aliasing=0 -O3 -pthread -Ideps/inih/ -Ideps/libev/ -Isrc/')
 env_statsite_without_err = Environment(CCFLAGS = '-g -std=c99 -D_GNU_SOURCE -O3 -pthread -Ideps/inih/ -Ideps/libev/ -Isrc/')
 
 objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + \


### PR DESCRIPTION
There are no warnings whatsoever with newer gcc (4.7.3). 

Feel free to reject this pull request :) I understand that compatibility with ancient compilers is not a priority. 

```
$ gcc --version
gcc (GCC) 4.1.2 20080704 (Red Hat 4.1.2-44)
...
cc1: warnings being treated as errors
src/cm_quantile.c: In function 'cm_insert':
src/cm_quantile.c:254: warning: dereferencing type-punned pointer will break strict-aliasing rules
src/cm_quantile.c:274: warning: dereferencing type-punned pointer will break strict-aliasing rules
src/cm_quantile.c:275: warning: dereferencing type-punned pointer will break strict-aliasing rules
src/cm_quantile.c:293: warning: dereferencing type-punned pointer will break strict-aliasing rules
src/cm_quantile.c:294: warning: dereferencing type-punned pointer will break strict-aliasing rules
```
