### PR TITLE
Improve graphite sink to avoid "invalid line received from client".

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -41,13 +41,16 @@ class GraphiteStore(object):
        :Parameters:
         - `metrics` : A list of (key,value,timestamp) tuples.
         """
+        if not metrics:
+            return
+
         # Construct the output
         metrics = [m.split("|") for m in metrics if m]
         self.logger.info("Outputting %d metrics" % len(metrics))
-        if not self.prefix:
-            lines = ["%s %s %s" % (k, v, ts) for k, v, ts in metrics]
-        else:
+        if self.prefix:
             lines = ["%s.%s %s %s" % (self.prefix, k, v, ts) for k, v, ts in metrics]
+        else:
+            lines = ["%s %s %s" % (k, v, ts) for k, v, ts in metrics]
         data = "\n".join(lines) + "\n"
 
         # Serialize writes to the socket
@@ -93,5 +96,5 @@ if __name__ == "__main__":
     metrics = sys.stdin.read()
 
     # Flush
-    graphite.flush(metrics.split("\n"))
+    graphite.flush(metrics.splitlines())
     graphite.close()


### PR DESCRIPTION
The invalid line issue is that graphite sink is constantly sending to the graphite server the string "\n", even when it has not received any metrics and as a consequence it makes carbon give out errors.
