### PR TITLE
Added statsite.spec and "clean", "sdist", and "rpms" rules in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 build:
 	scons statsite
 
+clean:
+	rm -rfv ./dist ./statsite ./rpm-build
+
 test_runner:
 	scons test_runner
 
@@ -10,6 +13,22 @@ test: test_runner
 
 integ: build test
 	py.test integ/
+
+sdist: clean
+	mkdir -vp ./dist
+	tar --exclude statsite.tar.gz -czvf ./dist/statsite.tar.gz .
+
+rpms: sdist build
+	mkdir -vp rpm-build
+	cp -v dist/*.tar.gz rpm-build/
+	rpmbuild --define "_topdir %(pwd)/rpm-build" \
+        --define "_builddir %{_topdir}" \
+        --define "_rpmdir %{_topdir}" \
+        --define "_srcrpmdir %{_topdir}" \
+        --define "_specdir %{_topdir}" \
+        --define '_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm' \
+        --define "_sourcedir  %{_topdir}" \
+        -ba statsite.spec
 
 .PHONY: build test statsite_test
 

--- a/statsite.spec
+++ b/statsite.spec
@@ -1,0 +1,39 @@
+Name:		statsite
+Version:	0.5.1
+Release:	1%{?dist}
+Summary:	A C implementation of statsd.
+Group:		Applications
+License:	See the LICENSE file.
+URL:		https://github.com/armon/statsite
+Source0:	statsite.tar.gz
+BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildRequires:	scons
+AutoReqProv:	No
+
+%description
+
+Statsite is a metrics aggregation server. Statsite is based heavily on Etsy's StatsD
+https://github.com/etsy/statsd, and is wire compatible.
+
+%prep
+%setup -c %{name}-%{version}
+
+%build
+make %{?_smp_mflags}
+
+%install
+mkdir -vp $RPM_BUILD_ROOT/usr/bin
+install -m 755 statsite $RPM_BUILD_ROOT/usr/bin
+
+%clean
+make clean
+
+%files
+%defattr(-,root,root,-)
+%doc LICENSE
+%doc CHANGELOG.md
+%doc README.md
+/usr/bin/statsite
+
+%changelog
+


### PR DESCRIPTION
For those old timers like me who still like building RPMs.
