### PR TITLE
Fix urllib2 error handling

### DIFF
--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -229,8 +229,12 @@ class LibratoStore(object):
             self.logger.warning('Failed to send metrics to Librato: Code: %d. Response: %s' % \
                                 (error.code, body))
         except IOError as error:
-            self.logger.warning('Error when sending metrics Librato (%s)' % \
-                                (error.reason))
+            if hasattr(error, 'reason'):
+                self.logger.warning('Error when sending metrics Librato (%s)' % (error.reason))
+            elif hasattr(error, 'code'):
+                self.logger.warning('Error when sending metrics Librato (%s)' % (error.code))
+            else:   
+                self.logger.warning('Error when sending metrics Librato and I dunno why')
 
     def flush(self):
         """


### PR DESCRIPTION
a few urllib2 I/O exceptions return an error object without a reason attribute. if those happen the current code dies with an unhandled exception 
