### PR TITLE
Gmetric. Add ipv6 support.

### DIFF
--- a/sinks/gmetric.py
+++ b/sinks/gmetric.py
@@ -230,6 +230,5 @@ if __name__ == '__main__':
                 sys.exit(2)
         else:
             metric_type = p.type
-        print metric_type
         g.send(key, value, TYPE=metric_type, UNITS=p.units, SLOPE=p.slope, TMAX=p.tmax, DMAX=p.dmin, GROUP=p.group, SPOOF=p.spoof)
     sys.exit(0)


### PR DESCRIPTION
Add dual-stack support for gmetric sink.
Now something like this will work:

stream_cmd = python /opt/statsite/sinks/gmetric.py --host="fd25:d3b4:365d:2::4" --stdin
