### PR TITLE
rate&count metrics for counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ The value type is one of:
 * 0x8 : Histogram Floor Value
 * 0x9 : Histogram Bin Value
 * 0xa : Histogram Ceiling Value
+* 0xb : Count Rate
 * 0x80 OR `percentile` :  If the type OR's with 128 (0x80), then it is a
     percentile amount. The amount is OR'd with 0x80 to provide the type. For
     example (0x80 | 0x32) = 0xb2 is the 50% percentile or medium. The 95th

--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -166,7 +166,8 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % now, "counts.foobar|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_meters(self, servers):
         "Tests adding kv pairs"
@@ -249,7 +250,8 @@ class TestIntegUDP(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % now, "counts.foobar|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_meters(self, servers):
         "Tests adding kv pairs"

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -40,6 +40,7 @@ VAL_TYPE_MAP = {
     "hist_min": 8,
     "hist_bin": 9,
     "hist_max": 10,
+    "rate": 11,
     "percentile": 128,
 }
 
@@ -202,6 +203,7 @@ class TestInteg(object):
         assert format_output(now, "foobar", BIN_TYPES["c"], VAL_TYPE_MAP["stddev"], 100) in out
         assert format_output(now, "foobar", BIN_TYPES["c"], VAL_TYPE_MAP["min"], 100) in out
         assert format_output(now, "foobar", BIN_TYPES["c"], VAL_TYPE_MAP["max"], 300) in out
+        assert format_output(now, "foobar", BIN_TYPES["c"], VAL_TYPE_MAP["rate"], 600) in out
 
     def test_meters(self, servers):
         "Tests adding kv pairs"

--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -146,7 +146,8 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % now, "counts.foobar|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
@@ -158,7 +159,8 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|6000.000000|%d\n" % now, "counts.foobar|6000.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_meters_alias(self, servers):
         "Tests adding timing data with the 'h' alias"
@@ -295,7 +297,8 @@ class TestIntegUDP(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % now, "counts.foobar|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
@@ -306,7 +309,8 @@ class TestIntegUDP(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|6000.000000|%d\n" % now, "counts.foobar|6000.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_counters_no_newlines(self, servers):
         "Tests adding counters without a trailing new line"
@@ -317,7 +321,8 @@ class TestIntegUDP(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.zip|600.000000|%d\n" % now, "counts.zip|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.zip|600.000000|%d\ncounts.zip.rate|600.000000|%d\ncounts.zip.count|3|%d\n" % (now,now,now),
+                       "counts.zip|600.000000|%d\ncounts.zip.rate|600.000000|%d\ncounts.zip.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_meters(self, servers):
         "Tests adding kv pairs"

--- a/integ/test_stdin.py
+++ b/integ/test_stdin.py
@@ -125,7 +125,8 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % now, "counts.foobar|600.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|600.000000|%d\ncounts.foobar.rate|600.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
@@ -137,7 +138,8 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in ("counts.foobar|6000.000000|%d\n" % now, "counts.foobar|6000.000000|%d\n" % (now - 1))
+        assert out in ("counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now,now,now),
+                       "counts.foobar|6000.000000|%d\ncounts.foobar.rate|6000.000000|%d\ncounts.foobar.count|3|%d\n" % (now - 1, now - 1, now - 1))
 
     def test_meters(self, servers):
         "Tests adding kv pairs"

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -32,6 +32,7 @@
 #define BIN_OUT_HIST_FLOOR    0x8
 #define BIN_OUT_HIST_BIN      0x9
 #define BIN_OUT_HIST_CEIL     0xa
+#define BIN_OUT_RATE     0xb
 #define BIN_OUT_PCT     0x80
 
 // Macro to provide branch meta-data
@@ -95,6 +96,8 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
 
         case COUNTER:
             STREAM("%s%s|%f|%lld\n", prefix, name, counter_sum(value));
+            STREAM("%s%s.rate|%f|%lld\n", prefix, name, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
+            STREAM("%s%s.count|%lld|%lld\n", prefix, name, counter_count(value));
             break;
 
         case SET:
@@ -173,6 +176,7 @@ static int stream_formatter_bin(FILE *pipe, void *data, metric_type type, char *
             STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_STDDEV, counter_stddev(value));
             STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MIN, counter_min(value));
             STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MAX, counter_max(value));
+            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_RATE, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
             break;
 
         case SET:


### PR DESCRIPTION
This PR adds rate and count metrics for counters 
(count was previously computed but not written to output and rate is calculated similar to statsd)

Possible fix for #52
