### PR TITLE
reset errno to 0 after calling isatty

### DIFF
--- a/src/statsite.c
+++ b/src/statsite.c
@@ -89,6 +89,7 @@ void setup_syslog() {
     if (isatty(1)) {
         flags |= LOG_PERROR;
     }
+    errno = 0
     openlog("statsite", flags, LOG_LOCAL0);
 }
 


### PR DESCRIPTION
isatty(0) also changes errno when returns 0. This causes unexpected error handling.

> RETURN VALUE
>       isatty() returns 1 if fd is an open file descriptor referring to a terminal; otherwise 0 is returned, and errno is set to indicate the error.

I encounterd an error caused by this issue at  https://github.com/armon/statsite/blob/f7935745181ade7a36302f4fa5f8a63ce18a5fea/src/config.c#L82

I set _port_  to 0. Althouch strtol did not throw an error, errno had been set to EINVAL by isatty, and value_to_int returns 0 consequently.
