### PR TITLE
skip metrics that have the incorrect number of items in their list

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -45,7 +45,8 @@ class GraphiteStore(object):
             return
 
         # Construct the output
-        metrics = [m.split("|") for m in metrics if m]
+        metrics = [m.split("|") for m in metrics if m and m.count("|") == 3]
+
         self.logger.info("Outputting %d metrics" % len(metrics))
         if self.prefix:
             lines = ["%s%s %s %s" % (self.prefix, k, v, ts) for k, v, ts in metrics]


### PR DESCRIPTION
This deals with metrics that have an incorrect number of items in the list. More specifically this handles stats that have a pipe character in their name. Without this, the graphite sink unsuccessfully processes all metrics and errors out with `too many values to unpack`
