### PR TITLE
Return code & global_prefix

### DIFF
--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -158,10 +158,14 @@ struct binary_out_prefix {
 
 static int stream_bin_writer(FILE *pipe, uint64_t timestamp, unsigned char type,
         unsigned char val_type, double val, char *name) {
-        uint16_t key_len = strlen(name) + 1;
-        struct binary_out_prefix out = {timestamp, type, val_type, key_len, val};
+        char *prefix = GLOBAL_CONFIG->prefixes_final[type];
+        uint16_t pre_len = strlen(prefix);
+        uint16_t key_len = strlen(name);
+        uint16_t tot_len = pre_len + key_len + 1;
+        struct binary_out_prefix out = {timestamp, type, val_type, tot_len, val};
         if (!fwrite(&out, sizeof(struct binary_out_prefix), 1, pipe)) return 1;
-        if (!fwrite(name, key_len, 1, pipe)) return 1;
+        if (!fwrite(prefix, pre_len, 1, pipe)) return 1; 
+        if (!fwrite(name, key_len + 1, 1, pipe)) return 1;
         return 0;
 }
 

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -34,7 +34,7 @@ int stream_to_command(metrics *m, void *data, stream_callback cb, char *cmd) {
     if (res < 0) return res;
 
     // Fork and exec
-    int status;
+    int status = 0;
     pid_t pid = fork();
     if (pid < 0) return res;
 


### PR DESCRIPTION
Hi,

I have found two bugs that were bothering me while testing statsite:
1) when binary stream is used, the prefixes are ignored
2) when streaming command returns quickly, statsite says in some situations that the command exited with an error code due to uninitialized variable.

Here I present you fixes to both bugs. Let me know, if you have any comments.

Thanks,
Foxnet
