### PR TITLE
Fix a couple of build issues

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ command -v libtoolize >/dev/null 2>&1 && libtoolize --force --copy
 # Execute glibtoolize as that's what OSX has, usually
 command -v glibtoolize >/dev/null 2>&1 && glibtoolize --force --copy
 
-#autoheader # We dont need this (yet?)
+autoheader # We dont need this (yet?)
 
 automake --add-missing --copy
 autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_PROG_LN_S
 AC_CHECK_LIB([rt], [clock_gettime], [LINK_TO_RT=-lrt], [LINK_TO_RT=])
 
 
-Checks for header files.
+# Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h strings.h sys/socket.h sys/time.h syslog.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
* buildconfig.h.in does not get generated without 'autoheader' in
  bootstrap.sh
* add the missing '#' to 'Checks for header files' which is meant
  to be a comment. Otherwise, 'configure' will complain about
  'Checks: command not found'