### PR TITLE
Add udp_rcvbuf configuration option to support larger socket buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ options must exist in the `statsite` section of the INI file:
 
 * udp\_port : Integer, sets the UDP port. Default 8125. 0 to disable.
 
+* udp_rcvbuf : Integer, sets the SO_RCVBUF socket buffer on the UDP port.
+  Defaults to 0 which does not change the OS default setting.
+
 * bind\_address : The address to bind on. Defaults to 0.0.0.0
 
 * parse\_stdin: Enables parsing stdin as an input stream. Defaults to 0.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ options must exist in the `statsite` section of the INI file:
 
 * udp\_port : Integer, sets the UDP port. Default 8125. 0 to disable.
 
-* udp_rcvbuf : Integer, sets the SO_RCVBUF socket buffer on the UDP port.
+* udp_rcvbuf : Integer, sets the SO_RCVBUF socket buffer in bytes on the UDP port.
   Defaults to 0 which does not change the OS default setting.
 
 * bind\_address : The address to bind on. Defaults to 0.0.0.0

--- a/src/config.c
+++ b/src/config.c
@@ -29,6 +29,7 @@ static double default_quantiles[] = {0.5, 0.95, 0.99};
 static const statsite_config DEFAULT_CONFIG = {
     8125,               // TCP defaults to 8125
     8125,               // UDP on 8125
+    0,                  // RCVBUF for UDP sockets unchanged from OS default
     "::",               // Listen on all addresses
     false,              // Do not parse stdin by default
     "DEBUG",            // DEBUG level
@@ -311,6 +312,8 @@ static int config_callback(void* user, const char* section, const char* name, co
         return value_to_int(value, &config->tcp_port);
     } else if (NAME_MATCH("udp_port")) {
         return value_to_int(value, &config->udp_port);
+    } else if (NAME_MATCH("udp_rcvbuf")) {
+        return value_to_int(value, &config->udp_rcvbuf);
     } else if (NAME_MATCH("flush_interval")) {
          return value_to_int(value, &config->flush_interval);
     } else if (NAME_MATCH("parse_stdin")) {

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,7 @@ typedef struct histogram_config {
 typedef struct {
     int tcp_port;
     int udp_port;
+    int udp_rcvbuf;
     char *bind_address;
     bool parse_stdin;
     char *log_level;

--- a/src/networking.c
+++ b/src/networking.c
@@ -232,6 +232,14 @@ static int setup_udp_listener(statsite_networking *netconf) {
     int flags = fcntl(udp_listener_fd, F_GETFL, 0);
     fcntl(udp_listener_fd, F_SETFL, flags | O_NONBLOCK);
 
+    // Set the RCVBUF socket buffer
+    if (netconf->config->udp_rcvbuf) {
+        optval = netconf->config->udp_rcvbuf;
+        if (setsockopt(udp_listener_fd, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval))) {
+            syslog(LOG_ERR, "Failed to set SO_RCVBUF! Err: %s\n", strerror(errno));
+        }
+    }
+
     // Allocate a connection object for the UDP socket,
     // ensure a min-buffer size of 64K
     conn_info *conn = get_conn(netconf, udp_listener_fd);


### PR DESCRIPTION
This adds a configuration option to the Statsite config file called
`udp_rcvbuf` which is used to make a setsockopt() call on the UDP
listen socket to set the SO_RCVBUF option.

Busy UDP sockets can benefit from having a larger than normal socket buffer
compared to the rmem_default setting.  This allows one to instruct
Statsite to set a different size buffer for the UDP socket.  Presumably,
rmem_max.