### PR TITLE
statsite debianization

### DIFF
--- a/debian/conf/statsite.conf
+++ b/debian/conf/statsite.conf
@@ -6,7 +6,7 @@ log_facility = local0
 flush_interval = 10
 timer_eps = 0.01
 set_eps = 0.02
-stream_cmd = python sinks/graphite.py localhost 2003 statsite
+stream_cmd = python /usr/share/statsite/sinks/graphite.py localhost 2003 statsite
 
 [histogram_api]
 prefix=api

--- a/debian/conf/statsite.conf
+++ b/debian/conf/statsite.conf
@@ -1,0 +1,21 @@
+[statsite]
+port = 8125
+udp_port = 8125
+log_level = INFO
+log_facility = local0
+flush_interval = 10
+timer_eps = 0.01
+set_eps = 0.02
+stream_cmd = python sinks/graphite.py localhost 2003 statsite
+
+[histogram_api]
+prefix=api
+min=0
+max=100
+width=5
+
+[histogram_default]
+prefix=
+min=0
+max=200
+width=20

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9),
                dh-autoreconf,
                dh-systemd,
-               check,
+               check (>= 0.10.0),
                python-pytest
 
 Package: statsite

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9),
                dh-autoreconf,
                dh-systemd,
+               pkg-config,
                check (>= 0.10.0),
                python-pytest
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Keates <john@keates.nl>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9), dh-autoreconf, check, python-pytest
 
 Package: statsite
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,8 @@ Build-Depends: debhelper (>= 9),
                dh-autoreconf,
                dh-systemd,
                pkg-config,
+               lsof,
+               netcat-openbsd,
                check (>= 0.10.0),
                python-pytest
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,11 @@ Maintainer: John Keates <john@keates.nl>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dh-autoreconf, check, python-pytest
+Build-Depends: debhelper (>= 9),
+               dh-autoreconf,
+               dh-systemd,
+               check,
+               python-pytest
 
 Package: statsite
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,5 @@
 	dh $@ --with autoreconf,systemd
 
 override_dh_auto_install:
-	rm sinks/*.pyc
+	rm -f sinks/*.pyc
 	dh_auto_install

--- a/debian/rules
+++ b/debian/rules
@@ -1,3 +1,8 @@
 #!/usr/bin/make -f
+
 %:
-	dh $@
+	dh $@ --with autoreconf
+
+	override_dh_auto_install:
+		rm sinks/*.pyc
+		dh_auto_install

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,8 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with autoreconf
+	dh $@ --with autoreconf,systemd
 
-	override_dh_auto_install:
-		rm sinks/*.pyc
-		dh_auto_install
+override_dh_auto_install:
+	rm sinks/*.pyc
+	dh_auto_install

--- a/debian/statsite.dirs
+++ b/debian/statsite.dirs
@@ -1,0 +1,1 @@
+var/lib/statsite

--- a/debian/statsite.dirs
+++ b/debian/statsite.dirs
@@ -1,1 +1,0 @@
-var/run/statsite

--- a/debian/statsite.dirs
+++ b/debian/statsite.dirs
@@ -1,1 +1,1 @@
-var/lib/statsite
+var/run/statsite

--- a/debian/statsite.install
+++ b/debian/statsite.install
@@ -1,0 +1,1 @@
+debian/conf/statsite.conf etc/statsite

--- a/debian/statsite.links
+++ b/debian/statsite.links
@@ -1,0 +1,1 @@
+/lib/init/upstart-job /etc/init.d/statsite

--- a/debian/statsite.postinst
+++ b/debian/statsite.postinst
@@ -1,0 +1,37 @@
+#! /bin/sh
+# postinst script for statsite
+#
+
+set -e
+
+PACKAGE="statsite"
+USER="${PACKAGE}"
+GROUP="${PACKAGE}"
+HOME="/var/run/${PACKAGE}"
+
+case "$1" in
+configure)
+
+	if ! getent passwd -- "${USER}" >/dev/null 2>&1 ; then
+	adduser --home "${HOME}" \
+		--group \
+		--system \
+		--disabled-password \
+		--no-create-home \
+		--gecos "Debian Statsite daemon user" \
+		"${USER}"
+	fi
+
+    OWNER=$(env stat -c '%U' "${HOME}")
+    if [ -d "${HOME}" ] && [ "x$OWNER" = "x$USER" ] ; then
+        echo 'Fixing permissions ...'
+        if ! dpkg-statoverride --list "${HOME}" >/dev/null 2>&1; then
+            dpkg-statoverride --update --add "${USER}" "${GROUP}" 0755 "${HOME}"
+        fi
+    fi
+;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/debian/statsite.postinst
+++ b/debian/statsite.postinst
@@ -4,31 +4,19 @@
 
 set -e
 
-PACKAGE="statsite"
-USER="${PACKAGE}"
-GROUP="${PACKAGE}"
-HOME="/var/run/${PACKAGE}"
-
 case "$1" in
 configure)
 
-	if ! getent passwd -- "${USER}" >/dev/null 2>&1 ; then
-	adduser --home "${HOME}" \
+	if ! getent passwd -- statsite >/dev/null 2>&1 ; then
+	adduser --home /nonexistent \
 		--group \
 		--system \
 		--disabled-password \
 		--no-create-home \
 		--gecos "Debian Statsite daemon user" \
-		"${USER}"
+		statsite
 	fi
 
-    OWNER=$(env stat -c '%U' "${HOME}")
-    if [ -d "${HOME}" ] && [ "x$OWNER" = "x$USER" ] ; then
-        echo 'Fixing permissions ...'
-        if ! dpkg-statoverride --list "${HOME}" >/dev/null 2>&1; then
-            dpkg-statoverride --update --add "${USER}" "${GROUP}" 0755 "${HOME}"
-        fi
-    fi
 ;;
 esac
 

--- a/debian/statsite.prerm
+++ b/debian/statsite.prerm
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+# byte-compiled Python libraries cleanup
+rm -f /usr/share/statsite/sinks/*.pyc
+
+exit 0

--- a/debian/statsite.service
+++ b/debian/statsite.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Statsite metrics aggregation server
+
+[Service]
+Type=forking
+User=statsite
+Group=statsite
+RuntimeDirectory=/var/run/statsite
+PIDFile=/var/run/statsite/statsite.pid
+ExecStart=/usr/bin/statsite -f /etc/statsite/statsite.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/statsite.service
+++ b/debian/statsite.service
@@ -4,8 +4,6 @@ Description=Statsite metrics aggregation server
 [Service]
 User=statsite
 Group=statsite
-RuntimeDirectory=statsite
-PIDFile=/var/run/statsite/statsite.pid
 ExecStart=/usr/bin/statsite -f /etc/statsite/statsite.conf
 Restart=on-failure
 

--- a/debian/statsite.service
+++ b/debian/statsite.service
@@ -2,10 +2,9 @@
 Description=Statsite metrics aggregation server
 
 [Service]
-Type=forking
 User=statsite
 Group=statsite
-RuntimeDirectory=/var/run/statsite
+RuntimeDirectory=statsite
 PIDFile=/var/run/statsite/statsite.pid
 ExecStart=/usr/bin/statsite -f /etc/statsite/statsite.conf
 Restart=on-failure

--- a/debian/statsite.upstart
+++ b/debian/statsite.upstart
@@ -18,15 +18,4 @@ pre-start script
     test -r /etc/statsite/statsite.conf || { stop; exit 1; }
 end script
 
-script
-    exec /usr/bin/statsite -f /etc/statsite/statsite.conf
-end script
-
-post-start script
-  PID=`status statsite | egrep -oi '([0-9]+)$' | head -n1`
-  echo $PID > /var/run/statsite/statsite.pid
-end script
-
-post-stop script
-  rm -f /var/run/statsite/statsite.pid
-end script
+exec /usr/bin/statsite -f /etc/statsite/statsite.conf

--- a/debian/statsite.upstart
+++ b/debian/statsite.upstart
@@ -1,0 +1,21 @@
+#
+# Statsite metrics aggregation server
+#
+
+description     "statsite"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+setuid statsite
+setgid statsite
+
+respawn
+respawn limit 10 5
+console log
+
+pre-start script
+    test -r /etc/statsite/statsite.conf || { stop; exit 1; }
+end script
+
+exec /usr/bin/statsite -f /etc/statsite/statsite.conf

--- a/debian/statsite.upstart
+++ b/debian/statsite.upstart
@@ -7,15 +7,26 @@ description     "statsite"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-setuid statsite
-setgid statsite
-
 respawn
 respawn limit 10 5
 console log
+
+setuid statsite
+setgid statsite
 
 pre-start script
     test -r /etc/statsite/statsite.conf || { stop; exit 1; }
 end script
 
-exec /usr/bin/statsite -f /etc/statsite/statsite.conf
+script
+    exec /usr/bin/statsite -f /etc/statsite/statsite.conf
+end script
+
+post-start script
+  PID=`status statsite | egrep -oi '([0-9]+)$' | head -n1`
+  echo $PID > /var/run/statsite/statsite.pid
+end script
+
+post-stop script
+  rm -f /var/run/statsite/statsite.pid
+end script


### PR DESCRIPTION
Updated debianization, tested with Trusty/Xenial
check-0.10.0 doesn't come with Trusty, I use Xenial-backported in-house build.
changes file wasn't updated as I don't rely on it (it's updated during my build process)