### PR TITLE
Graphite sink whitespaces

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -51,12 +51,13 @@ class GraphiteStore(object):
 
         self.logger.info("Outputting %d metrics" % len(metrics))
 
-        # Construct the output, ensure no spaces in metric name
+        # Construct the output, ensure no spaces and slashes in metric name
         lines = list()
         for m in metrics:
             if m.count("|") == 2:
                 met = m.split("|")
-                lines.append("%s %s %s" % (self.prefix + met[0].strip().replace(" ", "_"), met[2], met[1]))
+                met[0] = met[0].strip().replace(" ", "_").replace("/", "_")
+                lines.append("%s %s %s" % (self.prefix + met[0], met[2], met[1]))
 
         data = "\n".join(lines) + "\n"
 

--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -49,14 +49,15 @@ class GraphiteStore(object):
         if not metrics:
             return
 
-        # Construct the output
-        metrics = [m.split("|") for m in metrics if m and m.count("|") == 2]
-
         self.logger.info("Outputting %d metrics" % len(metrics))
-        if self.prefix:
-            lines = ["%s%s %s %s" % (self.prefix, k, v, ts) for k, v, ts in metrics]
-        else:
-            lines = ["%s %s %s" % (k, v, ts) for k, v, ts in metrics]
+
+        # Construct the output, ensure no spaces in metric name
+        lines = list()
+        for m in metrics:
+            if m.count("|") == 2:
+                met = m.split("|")
+                lines.append("%s %s %s" % (self.prefix + met[0].strip().replace(" ", "_"), met[2], met[1]))
+
         data = "\n".join(lines) + "\n"
 
         # Serialize writes to the socket


### PR DESCRIPTION
- removed prefix special handling as it is always defined (might need bool handling but it should be done on class init)
- ensure no spaces and slashes in metric name, replace with underscore