### PR TITLE
Improved graphite sink

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -1,6 +1,7 @@
 """
 Supports flushing metrics to graphite
 """
+import re
 import sys
 import socket
 import logging
@@ -11,10 +12,14 @@ import struct
 # Initialize the logger
 logging.basicConfig()
 
+SPACES = re.compile(r"\s+")
+SLASHES = re.compile(r"\/+")
+NON_ALNUM = re.compile(r"[^a-zA-Z_\-0-9\.]")
+
 
 class GraphiteStore(object):
     def __init__(self, host="localhost", port=2003, prefix="statsite.", attempts=3,
-                 protocol='lines'):
+                 protocol='lines', normalize=None):
         """
         Implements an interface that allows metrics to be persisted to Graphite.
         Raises a :class:`ValueError` on bad arguments.
@@ -24,6 +29,8 @@ class GraphiteStore(object):
             - `port` : The port of the graphite server
             - `prefix` (optional) : A prefix to add to the keys. Defaults to 'statsite.'
             - `attempts` (optional) : The number of re-connect retries before failing.
+            - `normalize` (optional) : If set, attempt to sanitize/normalize keys to be more
+               generally compliant with graphite/carbon expectations.
         """
         # Convert the port to an int since its coming from a configuration file
         port = int(port)
@@ -36,6 +43,11 @@ class GraphiteStore(object):
         if protocol not in ["pickle", "lines"]:
             raise ValueError("Supported protocols are pickle, lines")
 
+        if normalize is not None and normalize not in ("False", "false", "No", "no"):
+            self.normalize_func = self.normalize_key
+        else:
+            self.normalize_func = lambda k: "%s%s" % (self.prefix, k)
+
         self.logger = logging.getLogger("statsite.graphitestore")
         self.host = host
         self.port = port
@@ -43,31 +55,40 @@ class GraphiteStore(object):
         self.attempts = attempts
         self.sock = self._create_socket()
         self.flush = self.flush_pickle if protocol == "pickle" else self.flush_lines
+        self.metrics = []
 
-    def flush_lines(self, metrics):
+    def normalize_key(self, key):
+        """
+        Take a single key string and return the same string with spaces, slashes and
+        non-alphanumeric characters subbed out and prefixed by self.prefix.
+        """
+        key = SPACES.sub("_", key)
+        key = SLASHES.sub("-", key)
+        key = NON_ALNUM.sub("", key)
+        key = "%s%s" % (self.prefix, key)
+        return key
+
+    def append(self, metric):
+        """
+        Add one metric to queue for sending. Addtionally modify key to be compatible with txstatsd
+        format.
+
+        :Parameters:
+         - `metric` : A single statsd metric string in the format "key|value|timestamp".
+        """
+        if metric and metric.count("|") == 2:
+            k, v, ts = metric.split("|")
+            k = self.normalize_func(k)
+            self.metrics.append(((k), v, ts))
+
+    def flush_lines(self):
         """
         Flushes the metrics provided to Graphite.
-
-       :Parameters:
-        - `metrics` : A list of "key|value|timestamp" strings.
         """
-        if not metrics:
+        if not self.metrics:
             return
 
-        self.logger.info("Outputting %d metrics", len(metrics))
-
-        # Construct the output, ensure no spaces and slashes in metric name
-        # The data sent must be in the following format:
-        #     <metric path> <metric value> <metric timestamp>
-        # NOTE <metric value> <metric timestamp> are inverted with respect of pickle protocol
-        # http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol
-        lines = list()
-        for m in metrics:
-            if m.count("|") == 2:
-                met = m.split("|")
-                met[0] = met[0].strip().replace(" ", "_").replace("/", "_")
-                lines.append("%s %s %s" % (self.prefix + met[0], met[1], met[2]))
-
+        lines = ["%s %s %s" % metric for metric in self.metrics]
         data = "\n".join(lines) + "\n"
 
         # Serialize writes to the socket
@@ -76,14 +97,11 @@ class GraphiteStore(object):
         except StandardError:
             self.logger.exception("Failed to write out the metrics!")
 
-    def flush_pickle(self, metrics):
+    def flush_pickle(self):
         """
         Flushes the metrics provided to Graphite.
-
-       :Parameters:
-        - `metrics` : A list of "key|value|timestamp" strings.
         """
-        if not metrics:
+        if not self.metrics:
             return
 
         # transform a list of strings into the list of tuples that
@@ -91,18 +109,14 @@ class GraphiteStore(object):
         # (key, (timestamp, value))
         # http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-pickle-protocol
         metrics_fmt = []
-        for m in metrics:
-            if m.count("|") == 2:
-                met = m.split("|")
-                metrics_fmt.append((self.prefix + met[0], (met[2], met[1])))
+        for (k, v, ts) in self.metrics:
+            metrics_fmt.append((k, (ts, v)))
 
         # do pickle the list of tuples
         # add the header the pickle protocol wants
         payload = pickle.dumps(metrics_fmt, protocol=2)
         header = struct.pack("!L", len(payload))
         message = header + payload
-
-        self.logger.info("Outputting %d metrics", len(metrics))
 
         try:
             self._write_metric(message)
@@ -132,7 +146,7 @@ class GraphiteStore(object):
 
     def _write_metric(self, metric):
         """Tries to write a string to the socket, reconnecting on any errors"""
-        for attempt in xrange(self.attempts):
+        for _ in xrange(self.attempts):
             if self.sock:
                 try:
                     self.sock.sendall(metric)
@@ -147,14 +161,20 @@ class GraphiteStore(object):
 
 
 def main():
+
     # Intialize from our arguments
     graphite = GraphiteStore(*sys.argv[1:])
 
     # Get all the inputs
-    metrics = sys.stdin.read()
+    while True:
+        try:
+            graphite.append(raw_input().strip())
+        except EOFError:
+            break
 
     # Flush
-    graphite.flush(metrics.splitlines())
+    graphite.logger.info("Outputting %d metrics", len(graphite.metrics))
+    graphite.flush()
     graphite.close()
 
 

--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -69,7 +69,7 @@ class GraphiteStore(object):
         # Serialize writes to the socket
         try:
             self._write_metric(data)
-        except Exception:
+        except StandardError:
             self.logger.exception("Failed to write out the metrics!")
 
     def flush_pickle(self, metrics):
@@ -102,7 +102,7 @@ class GraphiteStore(object):
 
         try:
             self._write_metric(message)
-        except Exception:
+        except StandardError:
             self.logger.exception("Failed to write out the metrics!")
 
     def close(self):
@@ -113,7 +113,7 @@ class GraphiteStore(object):
         try:
             if self.sock:
                 self.sock.close()
-        except Exception:
+        except StandardError:
             self.logger.warning("Failed to close connection!")
 
     def _create_socket(self):
@@ -121,7 +121,7 @@ class GraphiteStore(object):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((self.host, self.port))
-        except Exception:
+        except StandardError:
             self.logger.error("Failed to connect!")
             sock = None
         return sock

--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -8,6 +8,10 @@ import pickle
 import struct
 
 
+# Initialize the logger
+logging.basicConfig()
+
+
 class GraphiteStore(object):
     def __init__(self, host="localhost", port=2003, prefix="statsite.", attempts=3,
                  protocol='lines'):
@@ -142,10 +146,7 @@ class GraphiteStore(object):
                              self.attempts)
 
 
-if __name__ == "__main__":
-    # Initialize the logger
-    logging.basicConfig()
-
+def main():
     # Intialize from our arguments
     graphite = GraphiteStore(*sys.argv[1:])
 
@@ -155,3 +156,7 @@ if __name__ == "__main__":
     # Flush
     graphite.flush(metrics.splitlines())
     graphite.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A handful of refactors to clean up the graphite sink and also not change the default behavior of not modifying key names which changed in #236 without, IMHO, adequate notice.

Sanitization of key name now follows behavior from txstatsd which squashes spaces into underbars, slashed into hyphens and all other non-alphanumeric gets dropped.

Also reduction of code in global scope and corrected overly broad exception handling.