### PR TITLE
align flush interval to clock

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -40,6 +40,7 @@ static const statsite_config DEFAULT_CONFIG = {
     "cat",              // Pipe to cat
     10,                 // Flush every 10 seconds
     0,                  // Do not daemonize
+    0,                  // Align flush interval to clock
     "/var/run/statsite.pid", // Default pidfile path
     0,                  // Do not use binary output by default
     NULL,               // Do not track number of messages received
@@ -320,6 +321,8 @@ static int config_callback(void* user, const char* section, const char* name, co
         return value_to_bool(value, &config->parse_stdin);
     } else if (NAME_MATCH("daemonize")) {
         return value_to_bool(value, &config->daemonize);
+    } else if (NAME_MATCH("aligned_flush")) {
+        return value_to_bool(value, &config->aligned_flush);
     } else if (NAME_MATCH("binary_stream")) {
         return value_to_bool(value, &config->binary_stream);
     } else if (NAME_MATCH("use_type_prefix")) {

--- a/src/config.h
+++ b/src/config.h
@@ -59,6 +59,7 @@ typedef struct {
     char *stream_cmd;
     int flush_interval;
     bool daemonize;
+    bool aligned_flush;
     char *pid_file;
     bool binary_stream;
     char *input_counter;

--- a/src/networking.c
+++ b/src/networking.c
@@ -280,6 +280,20 @@ static int setup_stdin_listener(statsite_networking *netconf) {
 }
 
 /**
+ * Adjust flush interval to align with clock
+ * @arg flush_interval The flush interval from configuration
+ */
+static long long align_timer(int flush_interval) {
+  long long next_flush_ms = flush_interval * 1000;
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  next_flush_ms -= (now.tv_sec % flush_interval) * 1000;
+  next_flush_ms -= (now.tv_usec / 1000);
+  if (next_flush_ms <= 0) next_flush_ms = flush_interval * 1000;
+  return next_flush_ms;
+}
+
+/**
  * Initializes the networking interfaces
  * @arg config Takes the bloom server configuration
  * @arg mgr The filter manager to pass up to the connection handlers
@@ -326,11 +340,7 @@ int init_networking(statsite_config *config, statsite_networking **netconf_out) 
     // Setup the timer
     long long first_flush_ms = config->flush_interval * 1000;
     if (config->aligned_flush) {
-      struct timeval now;
-      gettimeofday(&now, NULL);
-      first_flush_ms -= (now.tv_sec % config->flush_interval) * 1000;
-      first_flush_ms -= (now.tv_usec / 1000);
-      if (first_flush_ms <= 0) first_flush_ms = config->flush_interval * 1000;
+      first_flush_ms = align_timer(config->flush_interval);
     }
     netconf->flush_timer = aeCreateTimeEvent(netconf->loop, first_flush_ms, handle_flush_event, netconf, NULL);
 
@@ -353,11 +363,7 @@ static int handle_flush_event(aeEventLoop *loop, long long id, void *edata) {
     // Inform the connection handler of the timeout
     flush_interval_trigger();
     if (netconf->config->aligned_flush) {
-    struct timeval now;
-      gettimeofday(&now, NULL);
-      next_flush_ms -= (now.tv_sec % netconf->config->flush_interval) * 1000;
-      next_flush_ms -= (now.tv_usec / 1000);
-      if (next_flush_ms <= 0) next_flush_ms = netconf->config->flush_interval * 1000;
+      next_flush_ms = align_timer(netconf->config->flush_interval);
     }
     return next_flush_ms;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -324,7 +324,15 @@ int init_networking(statsite_config *config, statsite_networking **netconf_out) 
     }
 
     // Setup the timer
-    netconf->flush_timer = aeCreateTimeEvent(netconf->loop, config->flush_interval * 1000, handle_flush_event, netconf, NULL);
+    long long first_flush_ms = config->flush_interval * 1000;
+    if (config->aligned_flush) {
+      struct timeval now;
+      gettimeofday(&now, NULL);
+      first_flush_ms -= (now.tv_sec % config->flush_interval) * 1000;
+      first_flush_ms -= (now.tv_usec / 1000);
+      if (first_flush_ms <= 0) first_flush_ms = config->flush_interval * 1000;
+    }
+    netconf->flush_timer = aeCreateTimeEvent(netconf->loop, first_flush_ms, handle_flush_event, netconf, NULL);
 
     // Prepare the conn handlers
     init_conn_handler(config);
@@ -341,9 +349,17 @@ int init_networking(statsite_config *config, statsite_networking **netconf_out) 
  */
 static int handle_flush_event(aeEventLoop *loop, long long id, void *edata) {
     statsite_networking *netconf = (statsite_networking *) edata;
+    long long next_flush_ms = netconf->config->flush_interval * 1000;
     // Inform the connection handler of the timeout
     flush_interval_trigger();
-    return netconf->config->flush_interval * 1000;
+    if (netconf->config->aligned_flush) {
+    struct timeval now;
+      gettimeofday(&now, NULL);
+      next_flush_ms -= (now.tv_sec % netconf->config->flush_interval) * 1000;
+      next_flush_ms -= (now.tv_usec / 1000);
+      if (next_flush_ms <= 0) next_flush_ms = netconf->config->flush_interval * 1000;
+    }
+    return next_flush_ms;
 }
 
 


### PR DESCRIPTION
this should address #206 and #215, the new timer logic is enabled via a new configuration variable. defaulting to disabled, in which case there are no  changes to the timer behavior.

feedback and/or comments much appreciated

