### PR TITLE
add condensed and std targets for parser

### DIFF
--- a/src/ascii_parser.make
+++ b/src/ascii_parser.make
@@ -1,5 +1,11 @@
 
-all: ascii_parser_condensed.c ascii_parser_std.c
+.PHONY: std condensed
+
+std: ascii_parser_std.c
+	mv $< ascii_parser.c
+
+condensed: ascii_parser_condensed.c
+	mv $< ascii_parser.c
 
 ascii_parser_condensed.c: ascii_parser_condensed.rl
 	ragel $^ -o $@


### PR DESCRIPTION
this might help with autotools intgegration, running

`make -f ascii_parser.make [ std | condensed ]`

should build the appropriate parser 