### PR TITLE
Bump version inside spec file to build RPM

### DIFF
--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -1,7 +1,7 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 Name:		statsite
-Version:	0.8.0
+Version:	0.8.1
 Release:	1%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications


### PR DESCRIPTION
This fixes the error seen from a "make rpms" on RHEL7:
.....
statsite-0.8.1/config.status
statsite-0.8.1/Makefile
statsite-0.8.1/libtool
statsite-0.8.1/statsite-0.8.1.tar.gz
rm -r /tmp/statsite-0.8.1
rm: remove write-protected regular file ‘/tmp/statsite-0.8.1/.git/objects/pack/p                                                                                             ack-52fd7cab4ea93c41fd5b2d87811467fe547402f5.pack’? y
rm: remove write-protected regular file ‘/tmp/statsite-0.8.1/.git/objects/pack/p                                                                                             ack-52fd7cab4ea93c41fd5b2d87811467fe547402f5.idx’? y
mkdir -vp /tmp/rpm-build
cp -v *.tar.gz /tmp/rpm-build
‘statsite-0.8.1.tar.gz’ -> ‘/tmp/rpm-build/statsite-0.8.1.tar.gz’
cp -v rpm/statsite.spec /tmp/rpm-build
‘rpm/statsite.spec’ -> ‘/tmp/rpm-build/statsite.spec’
rpmbuild --define "_topdir /tmp/rpm-build" \
        --define "_builddir %{_topdir}" \
        --define "_rpmdir %{_topdir}" \
        --define "_srcrpmdir %{_topdir}" \
        --define "_specdir %{_topdir}" \
        --define '_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm' \
        --define "_sourcedir  %{_topdir}" \
        -ba /tmp/rpm-build/statsite.spec
error: File /tmp/rpm-build/statsite-0.8.0.tar.gz: No such file or directory
make: *** [rpms] Error 1
