### PR TITLE
spec and Makefile updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,7 +93,7 @@ sdist: clean
 	mkdir -vp /tmp/statsite-@STATSITE_VERSION@
 	cp -R . /tmp/statsite-@STATSITE_VERSION@
 	tar -zcv --exclude='.git' --exclude='.gitignore' -f statsite-@STATSITE_VERSION@.tar.gz -C /tmp statsite-@STATSITE_VERSION@
-	rm -r /tmp/statsite-@STATSITE_VERSION@
+	rm -rf /tmp/statsite-@STATSITE_VERSION@
 
 
 clean-local: clean-local-check

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -122,6 +122,7 @@ exit 0
 %attr(755, root, root) /usr/libexec/statsite/sinks/graphite.py
 %attr(755, root, root) /usr/libexec/statsite/sinks/cloudwatch.sh
 %attr(755, root, root) /usr/libexec/statsite/sinks/opentsdb.js
+%attr(755, root, root) /usr/libexec/statsite/sinks/http.py
 
 %changelog
 * Tue May 12 2015 Yann Ramin <yann@twitter.com> - 0.7.1-1


### PR DESCRIPTION
Force removal of /tmp/statsite directory without interaction.
Adding missing file to specfile to get rid of rpmbuild errors