### PR TITLE
Add a basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# This stage in the Dockerfile will not be included in the final image, as it
+# is only being used to build the statsite binary.
+FROM ubuntu:16.04 as builder
+
+RUN apt-get update && apt-get install -y build-essential check libtool \
+    automake autoconf gcc python python-requests scons pkg-config
+
+ADD . /build
+WORKDIR /build
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+# At this point, we have built the binary and have installed all of the
+# core files, which the following Dockerfile build stage will COPY in.
+
+# ----------------------------------------------------------------------------
+
+# This stage is what will be distributed. By pulling the compiled binary from
+# the previous stage, we lessen image bloat and installed package set.
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y python python-requests && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/bin/statsite /usr/local/bin/statsite
+COPY --from=builder /usr/local/share/statsite /usr/local/share/statsite
+
+# You'll need to mount your configuration in here.
+VOLUME /etc/statsite
+ENV STATSITE_CONFIG_PATH=/etc/statsite/statsite.conf
+
+ENTRYPOINT /usr/local/bin/statsite
+CMD -f ${STATSITE_CONFIG_PATH}


### PR DESCRIPTION
This PR adds a basic Dockerfile. This is a two-stage build, where the first stage being only for binary production. The second stage pulls the build binary and the sinks over from the first stage.

The user needs to mount their config file, though they can change the path where it lives by overriding the `STATSITE_CONFIG_PATH` env var.

I've kept the paths the same as what you'd get from doing a `make install` for consistency's sake.

The end result is that users a have an included and convenient way to build and/or deploy statsite in a containerized environment.