### PR TITLE
Add sink to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y python python-requests && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/statsite /usr/local/bin/statsite
-COPY --from=builder /usr/local/share/statsite /usr/local/share/statsite
+COPY --from=builder /usr/local/share/statsite/ /usr/local/share/statsite/
 
 # You'll need to mount your configuration in here.
 VOLUME /etc/statsite

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN ./autogen.sh
 RUN ./configure
 RUN make
 RUN make install
+COPY statsite.docker.example /etc/statsite/statsite.conf
 # At this point, we have built the binary and have installed all of the
 # core files, which the following Dockerfile build stage will COPY in.
 
@@ -21,12 +22,12 @@ RUN make install
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y python python-requests && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /etc/statsite/statsite.conf /etc/statsite/statsite.conf
 COPY --from=builder /usr/local/bin/statsite /usr/local/bin/statsite
 COPY --from=builder /usr/local/share/statsite/ /usr/local/share/statsite/
 
 # You'll need to mount your configuration in here.
 VOLUME /etc/statsite
-ENV STATSITE_CONFIG_PATH=/etc/statsite/statsite.conf
 
-ENTRYPOINT /usr/local/bin/statsite
-CMD -f ${STATSITE_CONFIG_PATH}
+ENTRYPOINT ["/usr/local/bin/statsite"]
+CMD ["-f","/etc/statsite/statsite.conf"]

--- a/statsite.docker.example
+++ b/statsite.docker.example
@@ -1,0 +1,20 @@
+[statsite]
+port=8125
+udp_port=8125
+log_level=INFO
+flush_interval=10
+timer_eps=0.01
+set_eps=0.02
+stream_cmd=python /usr/share/statsite/sinks/graphite.py localhost 2003
+
+[histogram_api]
+prefix=api
+min=0
+max=100
+width=5
+
+[histogram_default]
+prefix=
+min=0
+max=200
+width=20


### PR DESCRIPTION
There is 2 commits in this PR:

ece69e9 - The sinks weren't COPY correctly
b6207b4 - Added a example config file so that you can  have a worker container with a simple :
`docker run statsite/statsite:0.8.1-6`

And change CMD and ENTRYPOINT so you can override it easily
`docker run -v /mount/statsite:/tmp statsite/statsite:0.8.1-6 -f /tmp/statsite.conf`

I had issue using the ENV variable because it was incorrectly passed from the shell to the statsite