### PR TITLE
rpm/statsite.spec: update BuildRequires, %build steps.

### DIFF
--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -9,7 +9,7 @@ License:	See the LICENSE file.
 URL:		https://github.com/armon/statsite
 Source0:	%{name}-%{version}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd}
+BuildRequires:	libtool automake autoconf scons check-devel %{?el7:systemd} %{?fedora:systemd}
 AutoReqProv:	No
 Requires(pre):  shadow-utils
 
@@ -29,6 +29,8 @@ exit 0
 %setup
 
 %build
+./autogen.sh
+%configure
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
- BuildRequires to include autoconf, libtool utils
- Run ./autogen, %configure in %build stage.