### PR TITLE
Fix python warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Here is an example of the simplest possible Python sink:
     import sys
 
     lines = sys.stdin.read().split("\n")
-    metrics = [l.split("|") for l in lines]
+    metrics = [l.split("|") for l in lines if l]
 
     for key, value, timestamp in metrics:
         print key, value, timestamp


### PR DESCRIPTION
MacBook-Pro:statsite-0.8.0 lynch$ ./src/statsite -f ./rpm/statsite.conf
Mar 22 18:47:47  statsite[69606] <Info>: Starting statsite.
Mar 22 18:47:47  statsite[69606] <Info>: stdin is disabled
Mar 22 18:47:47  statsite[69606] <Info>: Listening on tcp ':::8125'
Mar 22 18:47:47  statsite[69606] <Info>: Listening on udp ':::8125'.
Traceback (most recent call last):
  File "/Users/lynch/Source/statsite-0.8.0/sinks/console.py", line 9, in <module>
    for key, value, timestamp in metrics:
ValueError: need more than 1 value to unpack
Mar 22 18:47:50  statsite[69606] <Warning>: Streaming command exited with status 1