### PR TITLE
Update debian dependencies for stretch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Keates <john@keates.nl>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dh-systemd, dh-autoreconf, dh-systemd, pkg-config, python-pytest
+Build-Depends: debhelper (>= 9), dh-systemd, dh-autoreconf, dh-systemd, pkg-config, python-pytest, python-mock, python-requests, netcat, lsof
 
 Package: statsite
 Architecture: any


### PR DESCRIPTION
When building in a clean environment (eg sbuild chroot), test suite
fails, if these packages are not installed.