### PR TITLE
statsd librato won't accept tag value with '=' char

### DIFF
--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -212,7 +212,7 @@ class LibratoStore(object):
             # Parse the tags out
             for raw_tag in raw_tags:
                 # Get the key and value from tag=value
-                tag_key, tag_value = raw_tag.split("=")
+                tag_key, tag_value = raw_tag.split("=", 1)
                 tags[tag_key] = tag_value
         return name, tags
                 


### PR DESCRIPTION
##### Bug description
When tag value is passed with '=' char, exception is raised:
```
tag_key, tag_value = raw_tag.split("=")
ValueError: too many values to unpack 
```

##### Fix description
Split the string on first char accurence only 