### PR TITLE
Fix for inconsistency accross #define and comment of hashmap_init

### DIFF
--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -25,12 +25,12 @@ extern void MurmurHash3_x64_128(const void * key, const int len, const uint32_t 
 
 /**
  * Creates a new hashmap and allocates space for it.
- * @arg initial_size The minimim initial size. 0 for default (64).
+ * @arg initial_size The minimim initial size. 0 for default (128).
  * @arg map Output. Set to the address of the map
  * @return 0 on success.
  */
 int hashmap_init(int initial_size, hashmap **map) {
-    // Default to 64 if no size
+    // Default to 128 if no size
     if (initial_size <= 0) {
        initial_size = DEFAULT_CAPACITY;
 

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -9,7 +9,7 @@ typedef int(*hashmap_callback)(void *data, const char *key, void *value);
 
 /**
  * Creates a new hashmap and allocates space for it.
- * @arg initial_size The minimim initial size. 0 for default (64).
+ * @arg initial_size The minimim initial size. 0 for default (128).
  * @arg map Output. Set to the address of the map
  * @return 0 on success.
  */


### PR DESCRIPTION
**bug description**

#define DEFAULT_CAPACITY 128

int hashmap_init(int initial_size, hashmap **map) comment says that default value is 64, yet sets the initial size to DEFAULT_CAPACITY should function parameter be less or equal to 0.

**fix description**

Fixed comment, assuming define value takes precedence.