### PR TITLE
Timer percentil

### DIFF
--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -222,18 +222,18 @@ class TestInteg(object):
 
         wait_file(output)
         out = open(output).read()
-        assert "timers.withrate.sum|4950" in out
-        assert "timers.withrate.sum_sq|328350" in out
+        assert "timers.withrate.sum|9900" in out
+        assert "timers.withrate.sum_sq|656700" in out
         assert "timers.withrate.mean|49.500000" in out
         assert "timers.withrate.lower|0.000000" in out
         assert "timers.withrate.upper|99.000000" in out
         assert "timers.withrate.count|200" in out
-        assert "timers.withrate.stdev|29.011492" in out
-        assert "timers.withrate.median|49.000000" in out
+        assert "timers.withrate.stdev|28.938507" in out
+        assert "timers.withrate.median|50.000000" in out
         assert "timers.withrate.p90|90.000000" in out
         assert "timers.withrate.p95|95.000000" in out
         assert "timers.withrate.p99|99.000000" in out
-        assert "timers.withrate.rate|4950" in out
+        assert "timers.withrate.rate|9900" in out
         assert "timers.withrate.sample_rate|200.0" in out
 
     def test_histogram(self, servers):

--- a/src/cm_quantile.h
+++ b/src/cm_quantile.h
@@ -36,7 +36,7 @@ typedef struct {
     uint64_t num_values;    // Number of values added
 
     cm_sample *samples;     // Sorted linked list of samples
-    cm_sample *end;         // Pointer to the end of the sampels
+    cm_sample *end;         // Pointer to the end of the samples
     heap *bufLess, *bufMore;// Sample buffer
 
     struct cm_insert_cursor insert;     // Insertion cursor
@@ -65,9 +65,10 @@ int destroy_cm_quantile(cm_quantile *cm);
  * Adds a new sample to the struct
  * @arg cm_quantile The cm_quantile to add to
  * @arg sample The new sample value
+ * @arg count number of samples to add
  * @return 0 on success.
  */
-int cm_add_sample(cm_quantile *cm, double sample);
+int cm_add_sample(cm_quantile *cm, double sample, uint64_t count);
 
 /**
  * Queries for a quantile value

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -443,7 +443,7 @@ void emit_stat(metric_type type,
     // Convert the value to a double
     val = str2double(value->start, &endptr);
     if (unlikely(endptr == value->start || errno == ERANGE)) {
-        syslog(LOG_WARNING, "Failed value conversion! Input: %.*s", value->len, value->start);
+        syslog(LOG_WARNING, "Failed value conversion! Input: %.*s", (int)value->len, value->start);
         return;
     }
 
@@ -451,7 +451,7 @@ void emit_stat(metric_type type,
     if ((type == COUNTER || type == TIMER) && samplerate->len > 1) {
         double unchecked_rate = str2double(samplerate->start, &endptr);
         if (unlikely(endptr == samplerate->start)) {
-            syslog(LOG_WARNING, "Failed sample rate conversion! Input: %.*s", samplerate->len, samplerate->start);
+            syslog(LOG_WARNING, "Failed sample rate conversion! Input: %.*s", (int)samplerate->len, samplerate->start);
             return;
         }
         if (likely(unchecked_rate > 0 && unchecked_rate <= 1)) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -4,8 +4,7 @@
 #include "cm_quantile.h"
 
 typedef struct {
-    uint64_t actual_count; // Actual items recieved
-    uint64_t count;     // Count of items (1 / sample rate)
+    uint64_t count;     // Count of items
     double sum;         // Sum of the values
     double squared_sum; // Sum of the squared values
     int finalized;      // Is the cm_quantile finalized

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -79,6 +79,8 @@ int main(void)
     tcase_add_test(tc4, test_timer_init_add_destroy);
     tcase_add_test(tc4, test_timer_add_loop);
     tcase_add_test(tc4, test_timer_sample_rate);
+    tcase_add_test(tc4, test_timer_sample_rate_2);
+    tcase_add_test(tc4, test_timer_variable_sample_rate);
 
     // Add the counter tests
     suite_add_tcase(s1, tc5);

--- a/tests/test_cm_quantile.c
+++ b/tests/test_cm_quantile.c
@@ -50,7 +50,7 @@ START_TEST(test_cm_init_add_destroy)
     int res = init_cm_quantile(0.01, (double*)&quants, 3, &cm);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, 100.0);
+    res = cm_add_sample(&cm, 100.0, 1);
     fail_unless(res == 0);
 
     res = destroy_cm_quantile(&cm);
@@ -67,7 +67,7 @@ START_TEST(test_cm_init_add_loop_destroy)
     fail_unless(res == 0);
 
     for (int i=0; i<1000; i++) {
-        res = cm_add_sample(&cm, i);
+        res = cm_add_sample(&cm, i, 1);
         fail_unless(res == 0);
     }
 
@@ -99,7 +99,7 @@ START_TEST(test_cm_init_add_query_destroy)
     int res = init_cm_quantile(0.01, (double*)&quants, 3, &cm);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, 100.0);
+    res = cm_add_sample(&cm, 100.0, 1);
     fail_unless(res == 0);
 
     double val = cm_query(&cm, 0.5);
@@ -117,13 +117,13 @@ START_TEST(test_cm_init_add3_query_destroy)
     int res = init_cm_quantile(0.01, (double*)&quants, 3, &cm);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, 100.0);
+    res = cm_add_sample(&cm, 100.0, 1);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, 200.0);
+    res = cm_add_sample(&cm, 200.0, 1);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, 300.0);
+    res = cm_add_sample(&cm, 300.0, 1);
     fail_unless(res == 0);
 
     res = cm_flush(&cm);
@@ -144,7 +144,7 @@ START_TEST(test_cm_init_add_negative_query_destroy)
     int res = init_cm_quantile(0.01, (double*)&quants, 3, &cm);
     fail_unless(res == 0);
 
-    res = cm_add_sample(&cm, -100.0);
+    res = cm_add_sample(&cm, -100.0, 1);
     fail_unless(res == 0);
 
     double val = cm_query(&cm, 0.5);
@@ -171,7 +171,7 @@ START_TEST(test_cm_init_add_loop_query_destroy)
     fail_unless(res == 0);
 
     for (int i=0; i < 100000; i++) {
-        res = cm_add_sample(&cm, i);
+        res = cm_add_sample(&cm, i, 1);
         fail_unless(res == 0);
     }
 
@@ -200,12 +200,12 @@ START_TEST(test_cm_init_add_loop_tail_query_destroy)
     fail_unless(res == 0);
 
     for (int i=0; i < 1000; i++) {
-        res = cm_add_sample(&cm, 1.0);
+        res = cm_add_sample(&cm, 1.0, 1);
         fail_unless(res == 0);
     }
 
     // Add a huge sample value (10M)
-    res = cm_add_sample(&cm, 10000000.0);
+    res = cm_add_sample(&cm, 10000000.0, 1);
     fail_unless(res == 0);
 
     res = cm_flush(&cm);
@@ -234,7 +234,7 @@ START_TEST(test_cm_init_add_loop_rev_query_destroy)
     fail_unless(res == 0);
 
     for (int i=100000; i > 0; i--) {
-        res = cm_add_sample(&cm, i);
+        res = cm_add_sample(&cm, i, 1);
         fail_unless(res == 0);
     }
 
@@ -264,7 +264,7 @@ START_TEST(test_cm_init_add_loop_random_query_destroy)
 
     srandom(42);
     for (int i=0; i < 100000; i++) {
-        res = cm_add_sample(&cm, random());
+        res = cm_add_sample(&cm, random(), 1);
         fail_unless(res == 0);
     }
 

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -80,17 +80,102 @@ START_TEST(test_timer_sample_rate)
       fail_unless(timer_add_sample(&t, i, 0.5) == 0);
 
   fail_unless(timer_count(&t) == 200);
-  fail_unless(timer_sum(&t) == 5050);
-  fail_unless(timer_squared_sum(&t) == 338350);
+  fail_unless(timer_sum(&t) == 10100);
+  fail_unless(timer_squared_sum(&t) == 676700);
   fail_unless(timer_min(&t) == 1);
   fail_unless(timer_max(&t) == 100);
   fail_unless(timer_mean(&t) == 50.5);
-  fail_unless(round(timer_stddev(&t)*1000)/1000 == 29.011);
-  fail_unless(timer_query(&t, 0.5) == 50);
+  fail_unless(round(timer_stddev(&t)*1000)/1000 == 28.939);
+  fail_unless(timer_query(&t, 0.5) >= 50 && timer_query(&t, 0.5) <= 51);
   fail_unless(timer_query(&t, 0.90) >= 89 && timer_query(&t, 0.90) <= 91);
   fail_unless(timer_query(&t, 0.99) >= 98 && timer_query(&t, 0.99) <= 100);
 
   res = destroy_timer(&t);
+  fail_unless(res == 0);
+}
+END_TEST
+
+static double diff(double a, double b) {
+    double m = fmax(a,b);
+    double part = abs(a - b);
+    return part / m;
+}
+
+START_TEST(test_timer_sample_rate_2)
+{
+  timer t, t1;
+  double quants[] = {0.5, 0.90, 0.99};
+  int res = init_timer(0.01, (double*)&quants, 3, &t);
+  fail_unless(res == 0);
+
+  res = init_timer(0.01, (double*)&quants, 3, &t1);
+  fail_unless(res == 0);
+
+  for (int i=0; i<100; i++) {
+      fail_unless(timer_add_sample(&t, i, 0.25) == 0);
+
+      fail_unless(timer_add_sample(&t1, i, 1) == 0);
+      fail_unless(timer_add_sample(&t1, i, 1) == 0);
+      fail_unless(timer_add_sample(&t1, i, 1) == 0);
+      fail_unless(timer_add_sample(&t1, i, 1) == 0);
+  }
+
+  fail_unless(timer_count(&t) == timer_count(&t1));
+  fail_unless(timer_sum(&t) == timer_sum(&t1));
+  fail_unless(timer_squared_sum(&t) == timer_squared_sum(&t1));
+  fail_unless(timer_min(&t) == timer_min(&t1));
+  fail_unless(timer_max(&t) == timer_max(&t1));
+  fail_unless(timer_mean(&t) == timer_mean(&t1));
+  fail_unless(diff(timer_stddev(&t), timer_stddev(&t1)) < 0.001);
+  fail_unless(diff(timer_query(&t, 0.5), timer_query(&t1, 0.5)) < 0.02);
+  fail_unless(diff(timer_query(&t, 0.90), timer_query(&t1, 0.90)) < 0.02);
+  fail_unless(diff(timer_query(&t, 0.99), timer_query(&t1, 0.99)) < 0.02);
+
+  res = destroy_timer(&t);
+  fail_unless(res == 0);
+
+  res = destroy_timer(&t1);
+  fail_unless(res == 0);
+}
+END_TEST
+
+
+START_TEST(test_timer_variable_sample_rate)
+{
+  timer t, t1;
+  double quants[] = {0.5, 0.90, 0.99};
+  int res = init_timer(0.01, (double*)&quants, 3, &t);
+  fail_unless(res == 0);
+
+  res = init_timer(0.01, (double*)&quants, 3, &t1);
+  fail_unless(res == 0);
+
+  srandom(42);
+
+  for (int i=0; i<100; i++) {
+      int count = ( random( ) % 100 ) + 1;
+
+      for (int c = 0; c < count; c++) {
+            fail_unless(timer_add_sample(&t1, i, 1) == 0);
+      }
+      fail_unless(timer_add_sample(&t, i, 1.0 / (double)count) == 0);
+  }
+
+  fail_unless(diff(timer_count(&t), timer_count(&t1)) < 0.001);
+  fail_unless(diff(timer_sum(&t), timer_sum(&t1)) < 0.001);
+  fail_unless(diff(timer_squared_sum(&t), timer_squared_sum(&t1)) < 0.001);
+  fail_unless(timer_min(&t) == timer_min(&t1));
+  fail_unless(timer_max(&t) == timer_max(&t1));
+  fail_unless(diff(timer_mean(&t), timer_mean(&t1)) < 0.001);
+  fail_unless(diff(timer_stddev(&t), timer_stddev(&t1)) < 0.001);
+  fail_unless(diff(timer_query(&t, 0.5), timer_query(&t1, 0.5)) <= 0.02);
+  fail_unless(diff(timer_query(&t, 0.90), timer_query(&t1, 0.90)) <= 0.02);
+  fail_unless(diff(timer_query(&t, 0.99), timer_query(&t1, 0.99)) <= 0.02);
+
+  res = destroy_timer(&t);
+  fail_unless(res == 0);
+
+  res = destroy_timer(&t1);
   fail_unless(res == 0);
 }
 END_TEST


### PR DESCRIPTION
### Accurate **percentiles** for timers with variable **sample-rate**

Current implementation supports **sample-rate** for **timers**, but assumes, that the **sample-rate** is always the same: 
```
process.time:3|ms|@0.25\n
process.time:3|ms|@0.25\n
process.time:3|ms|@0.25\n
process.time:2|ms|@0.25\n
process.time:2|ms|@0.25\n
process.time:1|ms|@0.25\n
```
and if you use variable **sample-rate**:
```
process.time:3|ms|@0.25\n
process.time:2|ms\n
process.time:1|ms|@0.5\n
```
**counts** would be computed correctly but **percentiles** could be calculated incorrectly.  This pull request solves the incorrect calculation of **percentiles**. 

### Motivation
instead of 
```
process.time:3|ms\n
process.time:3|ms\n
process.time:3|ms\n
process.time:3|ms\n
process.time:2|ms\n
process.time:1|ms\n
process.time:1|ms\n
```
you can now use **sample-rate** as a _rle-compression_  to achieve the same result
```
process.time:3|ms|@0.25\n
process.time:2|ms\n
process.time:1|ms|@0.5\n
```
this is very useful if you have many same messages, which you want to measure and want to save the network bandwidth and also the processing time in the statsite.
