### PR TITLE
Fix for tagged metric

### DIFF
--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -58,21 +58,21 @@ stream_cmd = %s
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -175,12 +175,12 @@ class TestInteg(object):
         "Tests adding kv pairs"
         server, _, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         out = open(output).read()
-        print out
+        print(out)
         assert "timers.noobs.sum|4950" in out
         assert "timers.noobs.sum_sq|328350" in out
         assert "timers.noobs.mean|49.500000" in out
@@ -259,12 +259,12 @@ class TestIntegUDP(object):
         "Tests adding kv pairs"
         _, server, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         out = open(output).read()
-        print out
+        print(out)
         assert "timers.noobs.sum|4950" in out
         assert "timers.noobs.sum_sq|328350" in out
         assert "timers.noobs.mean|49.500000" in out

--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -25,7 +25,8 @@ BINARY_SET_HEADER = struct.Struct("<BBHH")
 BIN_TYPES = {"kv": 1, "c": 2, "ms": 3, "set": 4, "g": 5, "delta": 6}
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -51,7 +51,8 @@ for x in xrange(1, 100):
     VAL_TYPE_MAP["P%02d" % x] = 128 | x
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -120,7 +121,8 @@ width=10
     return conn, conn2, output
 
 
-def pytest_funcarg__serversPrefix(request):
+@pytest.fixture
+def serversPrefix(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -161,7 +163,7 @@ width=10
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -47,7 +47,7 @@ VAL_TYPE_MAP = {
 }
 
 # Pre-compute all the possible percentiles
-for x in xrange(1, 100):
+for x in range(1, 100):
     VAL_TYPE_MAP["P%02d" % x] = 128 | x
 
 
@@ -92,21 +92,21 @@ width=10
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -169,15 +169,15 @@ width=10
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -277,7 +277,7 @@ class TestInteg(object):
         "Tests adding kv pairs"
         server, _, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
@@ -305,7 +305,7 @@ class TestInteg(object):
         "Tests streaming of histogram values"
         server, _, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("has_hist.test", "ms", x)
         server.sendall(msg)
         wait_file(output)
@@ -385,7 +385,7 @@ class TestIntegPrefix(object):
         "Tests adding kv pairs"
         server, _, output = serversPrefix
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
@@ -413,7 +413,7 @@ class TestIntegPrefix(object):
         "Tests streaming of histogram values"
         server, _, output = serversPrefix
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += format("has_hist.test", "ms", x)
         server.sendall(msg)
         wait_file(output)

--- a/integ/test_extended_counters.py
+++ b/integ/test_extended_counters.py
@@ -50,7 +50,7 @@ extended_counters = true
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
@@ -63,8 +63,8 @@ extended_counters = true
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -115,7 +115,7 @@ legacy_extended_counters = false
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
@@ -128,8 +128,8 @@ legacy_extended_counters = false
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now

--- a/integ/test_extended_counters.py
+++ b/integ/test_extended_counters.py
@@ -15,7 +15,8 @@ except ImportError:
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -55,7 +56,7 @@ extended_counters = true
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
@@ -78,7 +79,8 @@ extended_counters = true
     return conn, conn2, output
 
 
-def pytest_funcarg__servers_nonlegacy(request):
+@pytest.fixture
+def servers_nonlegacy(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -119,7 +121,7 @@ legacy_extended_counters = false
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)

--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -71,8 +71,8 @@ width=10
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -258,7 +258,7 @@ class TestInteg(object):
         "Tests adding timing data with the 'h' alias"
         server, _, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += "val:%d|h\n" % x
         server.sendall(msg)
 
@@ -545,7 +545,7 @@ class TestIntegUDP(object):
         "Tests adding kv pairs"
         _, server, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += "noobs:%d|ms\n" % x
         server.sendall(msg)
         wait_file(output)

--- a/integ/test_stdin.py
+++ b/integ/test_stdin.py
@@ -17,7 +17,8 @@ except ImportError:
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -56,7 +57,7 @@ width=10
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
@@ -75,126 +76,267 @@ def wait_file(path, timeout=5):
         time.sleep(0.1)
 
 
+def verify_line(line, test_set, times_list):
+    for test in test_set:
+        if line.startswith(test):
+            for t in times_list:
+                v = "%s%d\n" % (test, t)
+                if line == v:
+                    test_set.remove(test)
+                    return
+        else:
+            l = line.split('|')
+            t = test.split('|')
+            if l[0] == t[0]:
+                assert line == test, "value in line mismatch with test sets"
+
+    # line not founded
+    assert line in test_set, "line not found in test sets"
+
+def verify_lines(lines, test_set, times_list):
+    for line in lines:
+        verify_line(line, test_set, times_list)
+
+    # check for not founded test sets
+    assert not test_set, "test sets not found in out"
+
+def verify(output, test_set, times_list):
+    lines = open(output).readlines()
+    verify_lines(lines, test_set, times_list)
+
+
 class TestInteg(object):
     def test_kv(self, servers):
         "Tests adding kv pairs"
         server, output = servers
-        server.write("tubez:100|kv\n")
+
+        server.write("tubez1:100|kv\n")
+
+        server.write("tubez2;env=prod:50|kv\n") # Tagged metric
 
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("kv.tubez|100.000000|%d\n" % now, "kv.tubez|100.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "kv.tubez1|100.000000|",
+            "kv.tubez2;env=prod|50.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_gauges(self, servers):
         "Tests adding gauges"
         server, output = servers
+
         server.write("g1:1|g\n")
         server.write("g1:50|g\n")
+
+        server.write("g2;env=prod:4|g\n") # Tagged metric
+        server.write("g2;env=prod:5|g\n")
+
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("gauges.g1|50.000000|%d\n" % now, "gauges.g1|50.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "gauges.g1|50.000000|",
+            "gauges.g2;env=prod|5.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_gauges_delta(self, servers):
         "Tests adding gauges"
         server, output = servers
-        server.write("gd:+50|g\n")
-        server.write("gd:+50|g\n")
+
+        server.write("gd1:+50|g\n")
+        server.write("gd1:+50|g\n")
+
+        server.write("gd2;env=prod:+4|g\n") # Tagged metric
+        server.write("gd2;env=prod:+5|g\n")
+
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("gauges.gd|100.000000|%d\n" % now, "gauges.gd|100.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "gauges.gd1|100.000000|",
+            "gauges.gd2;env=prod|9.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_gauges_delta_neg(self, servers):
         "Tests adding gauges"
         server, output = servers
-        server.write("gd:-50|g\n")
-        server.write("gd:-50|g\n")
+
+        server.write("gd1:-50|g\n")
+        server.write("gd1:-50|g\n")
+
+        server.write("gd2;env=prod:+4|g\n") # Tagged metric
+        server.write("gd2;env=prod:-5|g\n")
+
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("gauges.gd|-100.000000|%d\n" % now, "gauges.gd|-100.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "gauges.gd1|-100.000000|",
+            "gauges.gd2;env=prod|-1.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_counters(self, servers):
-        "Tests adding kv pairs"
+        "Tests adding counters"
         server, output = servers
-        server.write("foobar:100|c\n")
-        server.write("foobar:200|c\n")
-        server.write("foobar:300|c\n")
+
+        server.write("foobar1:100|c\n")
+        server.write("foobar1:200|c\n")
+        server.write("foobar1:300|c\n")
+
+        server.write("foobar2;env=prod:2|c\n") # Tagged metric
+        server.write("foobar2;env=prod:3|c\n")
 
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("counts.foobar|600.000000|%d\n" % (now),
-                       "counts.foobar|600.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "counts.foobar1|600.000000|",
+            "counts.foobar2;env=prod|5.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_counters_sample(self, servers):
-        "Tests adding kv pairs"
+        "Tests adding counters sample"
         server, output = servers
-        server.write("foobar:100|c|@0.1\n")
-        server.write("foobar:200|c|@0.1\n")
-        server.write("foobar:300|c|@0.1\n")
+
+        server.write("foobar1:100|c|@0.1\n")
+        server.write("foobar1:200|c|@0.1\n")
+        server.write("foobar1:300|c|@0.1\n")
+
+        server.write("foobar2;env=prod:2|c|@0.1\n") # Tagged metric
+        server.write("foobar2;env=prod:3|c|@0.1\n")
 
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("counts.foobar|6000.000000|%d\n" % (now),
-                       "counts.foobar|6000.000000|%d\n" % (now - 1))
+
+        test_set = {
+            "counts.foobar1|6000.000000|",
+            "counts.foobar2;env=prod|50.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_meters(self, servers):
-        "Tests adding kv pairs"
+        "Tests adding meters"
         server, output = servers
         msg = ""
-        for x in xrange(100):
-            msg += "noobs:%d|ms\n" % x
+        for x in range(100):
+            msg += "noobs1:%d|ms\n" % x
+            msg += "noobs2;env=prod:%d|ms\n" % x # Tagged metric
+
         server.write(msg)
 
         wait_file(output)
-        out = open(output).read()
-        assert "timers.noobs.sum|4950" in out
-        assert "timers.noobs.sum_sq|328350" in out
-        assert "timers.noobs.mean|49.500000" in out
-        assert "timers.noobs.lower|0.000000" in out
-        assert "timers.noobs.upper|99.000000" in out
-        assert "timers.noobs.count|100" in out
-        assert "timers.noobs.stdev|29.011492" in out
-        assert "timers.noobs.median|49.000000" in out
-        assert "timers.noobs.p95|95.000000" in out
-        assert "timers.noobs.p99|99.000000" in out
+        now = time.time()
+
+        test_set = {
+            "timers.noobs1.sum|4950.000000|",
+            "timers.noobs1.sum_sq|328350.000000|",
+            "timers.noobs1.mean|49.500000|",
+            "timers.noobs1.lower|0.000000|",
+            "timers.noobs1.upper|99.000000|",
+            "timers.noobs1.count|100|",
+            "timers.noobs1.rate|4950.000000|",
+            "timers.noobs1.sample_rate|100.000000|",
+            "timers.noobs1.stdev|29.011492|",
+            "timers.noobs1.median|49.000000|",
+            "timers.noobs1.p50|49.000000|",
+            "timers.noobs1.p95|95.000000|",
+            "timers.noobs1.p99|99.000000|",
+            # Tagged metric
+            "timers.noobs2.sum;env=prod|4950.000000|",
+            "timers.noobs2.sum_sq;env=prod|328350.000000|",
+            "timers.noobs2.mean;env=prod|49.500000|",
+            "timers.noobs2.lower;env=prod|0.000000|",
+            "timers.noobs2.upper;env=prod|99.000000|",
+            "timers.noobs2.count;env=prod|100|",
+            "timers.noobs2.rate;env=prod|4950.000000|",
+            "timers.noobs2.sample_rate;env=prod|100.000000|",
+            "timers.noobs2.stdev;env=prod|29.011492|",
+            "timers.noobs2.median;env=prod|49.000000|",
+            "timers.noobs2.p50;env=prod|49.000000|",
+            "timers.noobs2.p95;env=prod|95.000000|",
+            "timers.noobs2.p99;env=prod|99.000000|"
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
     def test_histogram(self, servers):
         "Tests adding keys with histograms"
         server, output = servers
         msg = ""
-        for x in xrange(100):
-            msg += "has_hist.test:%d|ms\n" % x
+        for x in range(100):
+            msg += "has_hist.test1:%d|ms\n" % x
+            msg += "has_hist.test2;env=prod:%d|ms\n" % x * 10 # Tagged metric
         server.write(msg)
 
         wait_file(output)
+
         out = open(output).read()
-        assert "timers.has_hist.test.histogram.bin_<10.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_10.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_20.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_30.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_40.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_50.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_60.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_70.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_80.00|10" in out
-        assert "timers.has_hist.test.histogram.bin_>90.00|10" in out
+
+        assert "timers.has_hist.test1.histogram.bin_<10.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_10.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_20.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_30.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_40.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_50.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_60.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_70.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_80.00|10" in out
+        assert "timers.has_hist.test1.histogram.bin_>90.00|10" in out
+
+        # Tagged metric
+        assert "timers.has_hist.test2.histogram.bin_<10.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_10.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_20.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_30.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_40.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_50.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_60.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_70.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_80.00;env=prod|10" in out
+        assert "timers.has_hist.test2.histogram.bin_>90.00;env=prod|10" in out
 
     def test_sets(self, servers):
-        "Tests adding kv pairs"
+        "Tests adding sets"
         server, output = servers
-        server.write("zip:foo|s\n")
-        server.write("zip:bar|s\n")
-        server.write("zip:baz|s\n")
+
+        server.write("zip1:foo|s\n")
+        server.write("zip1:bar|s\n")
+        server.write("zip1:baz|s\n")
+
+        server.write("zip2;env=prod:foo|s\n") # Tagged metric
+        server.write("zip2;env=prod:bar|s\n")
 
         wait_file(output)
         now = time.time()
-        out = open(output).read()
-        assert out in ("sets.zip|3|%d\n" % now, "sets.zip|3|%d\n" % (now - 1))
+
+        now = time.time()
+
+        test_set = {
+            "sets.zip1|3|",
+            "sets.zip2;env=prod|2|",
+        }
+        times_list = [ now, now - 1 ]
+
+        verify(output, test_set, times_list)
 
 if __name__ == "__main__":
     sys.exit(pytest.main(args="-k TestInteg."))

--- a/integ/test_timers_include.py
+++ b/integ/test_timers_include.py
@@ -63,8 +63,8 @@ timers_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,SAMPLE_RATE
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now

--- a/integ/test_timers_include.py
+++ b/integ/test_timers_include.py
@@ -15,7 +15,8 @@ except ImportError:
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -49,13 +50,13 @@ timers_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,SAMPLE_RATE
             proc.wait()
             shutil.rmtree(tmpdir)
         except:
-            print proc
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
@@ -112,3 +113,5 @@ class TestInteg(object):
         assert "timers.foobar.sample_rate|3" in out
 
 
+if __name__ == "__main__":
+    sys.exit(pytest.main(args="-k TestInteg."))

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -8,6 +8,10 @@
 #include "hashmap.h"
 #include "set.h"
 
+char *metric_name_format(const char *name, const char *postfix);
+char *metric_name_format_pcnt(const char *name, const char *postfix, double pcnt);
+char *metric_name_format_hist(const char *name, const char *postfix, double hist);
+
 typedef struct key_val {
     char *name;
     double val;


### PR DESCRIPTION
For example counter with name `foobar2;env=prod`
Now statsite produce metrics like `foobar2;env=prod.sum` and etc.
This PR produce metric names like `foobar2.sum;env=prod`
