### PR TITLE
Add Meson build system and migrate integration tests to Python 3

### DIFF
--- a/buildconfig.h.in
+++ b/buildconfig.h.in
@@ -1,0 +1,1 @@
+#define VERSION "@VERSION@"

--- a/deps/murmurhash/MurmurHash3.c
+++ b/deps/murmurhash/MurmurHash3.c
@@ -14,7 +14,7 @@
 
 #define	FORCE_INLINE inline __attribute__((always_inline))
 
-inline uint64_t rotl64(uint64_t x, int8_t r){
+FORCE_INLINE uint64_t rotl64(uint64_t x, int8_t r){
   return (x << r) | (x >> (64 - r));
 }
 

--- a/integ/meson.build
+++ b/integ/meson.build
@@ -1,0 +1,29 @@
+py = import('python').find_installation(pure: false)
+
+foreach mod : ['pytest', 'six', 'requests']
+  if run_command(py, '-c', 'import ' + mod, check: false).returncode() != 0
+    error('Missing Python module: ' + mod + ' (used for integ tests)')
+  endif
+endforeach
+
+test_files = [
+  'test_binary.py',
+  'test_stdin.py',
+  'test_timers_include.py',
+  'test_binary_stream.py',
+  'test_extended_counters.py',
+  'test_http.py',
+  'test_integ.py',
+  'test_librato.py',
+]
+
+foreach test_file : test_files
+  test(
+    test_file,
+    py,
+    env: {
+      'STATSITE': statsite.full_path(),
+    },
+    args:['-m', 'pytest', meson.current_source_dir() / test_file]
+  )
+endforeach

--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -16,16 +16,18 @@ import struct
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
 BINARY_HEADER = struct.Struct("<BBHd")
 BINARY_SET_HEADER = struct.Struct("<BBHH")
 BIN_TYPES = {"kv": 1, "c": 2, "ms": 3, "set": 4, "g": 5, "delta": 6}
+STATSITE = os.environ.get("STATSITE", "./statsite")
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -46,7 +48,7 @@ stream_cmd = %s
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -56,22 +58,22 @@ stream_cmd = %s
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -88,22 +90,23 @@ stream_cmd = %s
 
 def format(key, type, val):
     "Formats a binary message for statsite"
-    key = str(key)
+    key = key.encode("utf-8")
     key_len = len(key) + 1
     type_num = BIN_TYPES[type]
     header = BINARY_HEADER.pack(170, type_num, key_len, float(val))
-    mesg = header + key + "\0"
+    mesg = header + key + b"\0"
     return mesg
+
 
 def format_set(key, val):
     "Formats a binary set message for statsite"
-    key = str(key)
+    key = key.encode("utf-8")
     key_len = len(key) + 1
-    val = str(val)
+    val = val.encode("utf-8")
     val_len = len(val) + 1
     type_num = BIN_TYPES["set"]
     header = BINARY_SET_HEADER.pack(170, type_num, key_len, val_len)
-    mesg = "".join([header, key, "\0", val, "\0"])
+    mesg = b"".join([header, key, b"\0", val, b"\0"])
     return mesg
 
 
@@ -173,13 +176,13 @@ class TestInteg(object):
     def test_meters(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         out = open(output).read()
-        print out
+        print(out)
         assert "timers.noobs.sum|4950" in out
         assert "timers.noobs.sum_sq|328350" in out
         assert "timers.noobs.mean|49.500000" in out
@@ -257,13 +260,13 @@ class TestIntegUDP(object):
     def test_meters(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         out = open(output).read()
-        print out
+        print(out)
         assert "timers.noobs.sum|4950" in out
         assert "timers.noobs.sum_sq|328350" in out
         assert "timers.noobs.mean|49.500000" in out

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -17,7 +17,7 @@ import struct
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
@@ -25,6 +25,7 @@ BINARY_HEADER = struct.Struct("<BBHd")
 BINARY_SET_HEADER = struct.Struct("<BBHH")
 COUNT_VAL = struct.Struct("<I")
 BIN_TYPES = {"kv": 1, "c": 2, "ms": 3, "set": 4, "g": 5}
+STATSITE = os.environ.get("STATSITE", "./statsite")
 
 BINARY_OUT_HEADER = struct.Struct("<QBBHd")
 BINARY_OUT_LEN = 20
@@ -47,11 +48,12 @@ VAL_TYPE_MAP = {
 }
 
 # Pre-compute all the possible percentiles
-for x in xrange(1, 100):
+for x in range(1, 100):
     VAL_TYPE_MAP["P%02d" % x] = 128 | x
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -80,7 +82,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -90,22 +92,22 @@ width=10
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -120,7 +122,8 @@ width=10
     return conn, conn2, output
 
 
-def pytest_funcarg__serversPrefix(request):
+@pytest.fixture
+def serversPrefix(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -150,7 +153,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -160,22 +163,22 @@ width=10
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -192,30 +195,30 @@ width=10
 
 def format(key, type, val):
     "Formats a binary message for statsite"
-    key = str(key)
+    key = key.encode("utf-8")
     key_len = len(key) + 1
     type_num = BIN_TYPES[type]
     header = BINARY_HEADER.pack(170, type_num, key_len, float(val))
-    mesg = header + key + "\0"
+    mesg = header + key + b"\0"
     return mesg
 
 
 def format_set(key, val):
     "Formats a binary set message for statsite"
-    key = str(key)
+    key = key.encode("utf-8")
     key_len = len(key) + 1
-    val = str(val)
+    val = val.encode("utf-8")
     val_len = len(val) + 1
     type_num = BIN_TYPES["set"]
     header = BINARY_SET_HEADER.pack(170, type_num, key_len, val_len)
-    mesg = "".join([header, key, "\0", val, "\0"])
+    mesg = b"".join([header, key, b"\0", val, b"\0"])
     return mesg
 
 
 def format_output(time, key, type, val_type, val):
     "Formats an response line. This is to check that we meet spec"
     prefix = BINARY_OUT_HEADER.pack(int(time), type, val_type, len(key) + 1, val)
-    return prefix + key + "\0"
+    return prefix + key.encode("utf-8") + b"\0"
 
 def format_output_count(time, key, type, val_type, val, count):
     "Formats a response line that includes a count, for histograms"
@@ -240,7 +243,7 @@ class TestInteg(object):
         server.sendall(format("tubez", "kv", 100))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
         assert out in (format_output(now, "tubez", BIN_TYPES["kv"], VAL_TYPE_MAP["kv"], 100),
                        format_output(now - 1, "tubez", BIN_TYPES["kv"], VAL_TYPE_MAP["kv"], 100))
 
@@ -250,7 +253,7 @@ class TestInteg(object):
         server.sendall(format("g1", "g", 500))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
         assert out in (format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500),
                        format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500))
 
@@ -262,7 +265,7 @@ class TestInteg(object):
         server.sendall(format("foobar", "c", 300))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "foobar", BIN_TYPES["c"], VAL_TYPE_MAP["count"], 600) in out:
@@ -274,13 +277,13 @@ class TestInteg(object):
     def test_meters(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "noobs", BIN_TYPES["ms"], VAL_TYPE_MAP["sum"], 4950) in out:
@@ -302,13 +305,13 @@ class TestInteg(object):
     def test_histogram(self, servers):
         "Tests streaming of histogram values"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("has_hist.test", "ms", x)
         server.sendall(msg)
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output_count(now - 1, "has_hist.test", BIN_TYPES["ms"], VAL_TYPE_MAP["hist_min"], 10, 10) in out:
@@ -333,7 +336,7 @@ class TestInteg(object):
         server.sendall(format_set("zip", "baz"))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "zip", BIN_TYPES["set"], VAL_TYPE_MAP["sum"], 3) in out:
@@ -348,7 +351,7 @@ class TestIntegPrefix(object):
         server.sendall(format("tubez", "kv", 100))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
         assert out in (format_output(now, "kv.tubez", BIN_TYPES["kv"], VAL_TYPE_MAP["kv"], 100),
                        format_output(now - 1, "kv.tubez", BIN_TYPES["kv"], VAL_TYPE_MAP["kv"], 100))
 
@@ -358,7 +361,7 @@ class TestIntegPrefix(object):
         server.sendall(format("g1", "g", 500))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
         assert out in (format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500),
                        format_output(now - 1, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500))
 
@@ -370,7 +373,7 @@ class TestIntegPrefix(object):
         server.sendall(format("foobar", "c", 300))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "counts.foobar", BIN_TYPES["c"], VAL_TYPE_MAP["count"], 3) in out:
@@ -382,13 +385,13 @@ class TestIntegPrefix(object):
     def test_meters(self, serversPrefix):
         "Tests adding kv pairs"
         server, _, output = serversPrefix
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("noobs", "ms", x)
         server.sendall(msg)
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "timers.noobs", BIN_TYPES["ms"], VAL_TYPE_MAP["sum"], 4950) in out:
@@ -410,13 +413,13 @@ class TestIntegPrefix(object):
     def test_histogram(self, serversPrefix):
         "Tests streaming of histogram values"
         server, _, output = serversPrefix
-        msg = ""
-        for x in xrange(100):
+        msg = b""
+        for x in range(100):
             msg += format("has_hist.test", "ms", x)
         server.sendall(msg)
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "timers.noobs", BIN_TYPES["ms"], VAL_TYPE_MAP["sum"], 4950) in out:
@@ -441,7 +444,7 @@ class TestIntegPrefix(object):
         server.sendall(format_set("zip", "baz"))
         wait_file(output)
         now = time.time()
-        out = open(output).read()
+        out = open(output, "rb").read()
 
         # Adjust for time drift
         if format_output(now - 1, "sets.zip", BIN_TYPES["set"], VAL_TYPE_MAP["sum"], 3) in out:

--- a/integ/test_extended_counters.py
+++ b/integ/test_extended_counters.py
@@ -11,11 +11,13 @@ import random
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
+STATSITE = os.environ.get("STATSITE", "./statsite")
 
 
-def pytest_funcarg__servers(request):
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -38,7 +40,7 @@ extended_counters = true
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -48,22 +50,22 @@ extended_counters = true
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -78,7 +80,8 @@ extended_counters = true
     return conn, conn2, output
 
 
-def pytest_funcarg__servers_nonlegacy(request):
+@pytest.fixture
+def servers_nonlegacy(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -102,7 +105,7 @@ legacy_extended_counters = false
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -112,22 +115,22 @@ legacy_extended_counters = false
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -157,9 +160,9 @@ class TestInteg(object):
     def test_counters(self, servers):
         "Tests adding counters with (legacy behaviour)"
         server, _, output = servers
-        server.sendall("foobar:100|c\n")
-        server.sendall("foobar:200|c\n")
-        server.sendall("foobar:300|c\n")
+        server.sendall(b"foobar:100|c\n")
+        server.sendall(b"foobar:200|c\n")
+        server.sendall(b"foobar:300|c\n")
 
         wait_file(output)
         out = open(output).read()
@@ -169,9 +172,9 @@ class TestInteg(object):
     def test_counters_sample(self, servers):
         "Tests adding counters with sampling (legacy behaviour)"
         server, _, output = servers
-        server.sendall("foobar:100|c|@0.1\n")
-        server.sendall("foobar:200|c|@0.1\n")
-        server.sendall("foobar:300|c|@0.1\n")
+        server.sendall(b"foobar:100|c|@0.1\n")
+        server.sendall(b"foobar:200|c|@0.1\n")
+        server.sendall(b"foobar:300|c|@0.1\n")
 
         wait_file(output)
         out = open(output).read()
@@ -181,9 +184,9 @@ class TestInteg(object):
     def test_counters_legacy(self, servers_nonlegacy):
         "Tests adding counters"
         server, _, output = servers_nonlegacy
-        server.sendall("foobar:100|c\n")
-        server.sendall("foobar:200|c\n")
-        server.sendall("foobar:300|c\n")
+        server.sendall(b"foobar:100|c\n")
+        server.sendall(b"foobar:200|c\n")
+        server.sendall(b"foobar:300|c\n")
 
         wait_file(output)
         out = open(output).read()
@@ -193,9 +196,9 @@ class TestInteg(object):
     def test_counters_sample_legacy(self, servers_nonlegacy):
         "Tests adding counters with sampling"
         server, _, output = servers_nonlegacy
-        server.sendall("foobar:100|c|@0.1\n")
-        server.sendall("foobar:200|c|@0.1\n")
-        server.sendall("foobar:300|c|@0.1\n")
+        server.sendall(b"foobar:100|c|@0.1\n")
+        server.sendall(b"foobar:200|c|@0.1\n")
+        server.sendall(b"foobar:300|c|@0.1\n")
 
         wait_file(output)
         out = open(output).read()

--- a/integ/test_http.py
+++ b/integ/test_http.py
@@ -2,7 +2,7 @@
 Testing the http sink
 """
 import json
-from mock import patch
+from unittest.mock import patch
 
 from sinks.http import StatsiteHttp
 

--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -13,11 +13,15 @@ import random
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+STATSITE = os.environ.get("STATSITE", "./statsite")
+
+
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -46,7 +50,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -56,22 +60,22 @@ width=10
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -101,7 +105,7 @@ class TestInteg(object):
     def test_kv(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        server.sendall("tubez:100|kv\n")
+        server.sendall(b"tubez:100|kv\n")
 
         wait_file(output)
         now = time.time()
@@ -111,8 +115,8 @@ class TestInteg(object):
     def test_gauges(self, servers):
         "Tests adding gauges"
         server, _, output = servers
-        server.sendall("g1:1|g\n")
-        server.sendall("g1:50|g\n")
+        server.sendall(b"g1:1|g\n")
+        server.sendall(b"g1:50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -121,8 +125,8 @@ class TestInteg(object):
     def test_gauges_delta(self, servers):
         "Tests adding gauges"
         server, _, output = servers
-        server.sendall("gd:+50|g\n")
-        server.sendall("gd:+50|g\n")
+        server.sendall(b"gd:+50|g\n")
+        server.sendall(b"gd:+50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -131,8 +135,8 @@ class TestInteg(object):
     def test_gauges_delta_neg(self, servers):
         "Tests adding gauges"
         server, _, output = servers
-        server.sendall("gd:-50|g\n")
-        server.sendall("gd:-50|g\n")
+        server.sendall(b"gd:-50|g\n")
+        server.sendall(b"gd:-50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -141,9 +145,9 @@ class TestInteg(object):
     def test_counters(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        server.sendall("foobar:100|c\n")
-        server.sendall("foobar:200|c\n")
-        server.sendall("foobar:300|c\n")
+        server.sendall(b"foobar:100|c\n")
+        server.sendall(b"foobar:200|c\n")
+        server.sendall(b"foobar:300|c\n")
 
         wait_file(output)
         now = time.time()
@@ -154,9 +158,9 @@ class TestInteg(object):
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        server.sendall("foobar:100|c|@0.1\n")
-        server.sendall("foobar:200|c|@0.1\n")
-        server.sendall("foobar:300|c|@0.1\n")
+        server.sendall(b"foobar:100|c|@0.1\n")
+        server.sendall(b"foobar:200|c|@0.1\n")
+        server.sendall(b"foobar:300|c|@0.1\n")
 
         wait_file(output)
         now = time.time()
@@ -167,9 +171,9 @@ class TestInteg(object):
     def test_meters_alias(self, servers):
         "Tests adding timing data with the 'h' alias"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
-            msg += "val:%d|h\n" % x
+        msg = b""
+        for x in range(100):
+            msg += b"val:%d|h\n" % x
         server.sendall(msg)
 
         wait_file(output)
@@ -191,9 +195,9 @@ class TestInteg(object):
     def test_meters(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
-            msg += "noobs:%d|ms\n" % x
+        msg = b""
+        for x in range(100):
+            msg += b"noobs:%d|ms\n" % x
         server.sendall(msg)
 
         wait_file(output)
@@ -215,9 +219,9 @@ class TestInteg(object):
     def test_timers_with_rate(self, servers):
         "Tests timers with sampling rate"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
-            msg += "withrate:%d|ms|@0.5\n" % x
+        msg = b""
+        for x in range(100):
+            msg += b"withrate:%d|ms|@0.5\n" % x
         server.sendall(msg)
 
         wait_file(output)
@@ -239,9 +243,9 @@ class TestInteg(object):
     def test_histogram(self, servers):
         "Tests adding keys with histograms"
         server, _, output = servers
-        msg = ""
-        for x in xrange(100):
-            msg += "has_hist.test:%d|ms\n" % x
+        msg = b""
+        for x in range(100):
+            msg += b"has_hist.test:%d|ms\n" % x
         server.sendall(msg)
 
         wait_file(output)
@@ -260,9 +264,9 @@ class TestInteg(object):
     def test_sets(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        server.sendall("zip:foo|s\n")
-        server.sendall("zip:bar|s\n")
-        server.sendall("zip:baz|s\n")
+        server.sendall(b"zip:foo|s\n")
+        server.sendall(b"zip:bar|s\n")
+        server.sendall(b"zip:baz|s\n")
 
         wait_file(output)
         now = time.time()
@@ -272,14 +276,14 @@ class TestInteg(object):
     def test_double_parsing(self, servers):
         "Tests string to double parsing"
         server, _, output = servers
-        server.sendall("int1:1|c\n")
-        server.sendall("decimal1:1.0|c\n")
-        server.sendall("decimal2:2.3456789|c\n")
-        server.sendall("scientific1:1.0e5|c\n")
-        server.sendall("scientific2:2.0e05|c\n")
-        server.sendall("scientific3:3.0E05|c\n")
-        server.sendall("scientific4:4.0e-5|c\n")
-        server.sendall("underflow1:1.964393875E-314|c\n")
+        server.sendall(b"int1:1|c\n")
+        server.sendall(b"decimal1:1.0|c\n")
+        server.sendall(b"decimal2:2.3456789|c\n")
+        server.sendall(b"scientific1:1.0e5|c\n")
+        server.sendall(b"scientific2:2.0e05|c\n")
+        server.sendall(b"scientific3:3.0E05|c\n")
+        server.sendall(b"scientific4:4.0e-5|c\n")
+        server.sendall(b"underflow1:1.964393875E-314|c\n")
 
         wait_file(output)
         out = open(output).read()
@@ -295,7 +299,7 @@ class TestInteg(object):
 #    def test_condensed(self, servers):
 #        "Tests adding condensed stats"
 #        _, server, output = servers
-#        server.sendall("foo:4|c:5|ms:3|ms:7|g\n")
+#        server.sendall(b"foo:4|c:5|ms:3|ms:7|g\n")
 #
 #        wait_file(output)
 #        now = time.time()
@@ -309,7 +313,7 @@ class TestIntegUDP(object):
     def test_kv(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("tubez:100|kv\n")
+        server.sendall(b"tubez:100|kv\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -318,8 +322,8 @@ class TestIntegUDP(object):
     def test_gauges(self, servers):
         "Tests adding gauges"
         _, server, output = servers
-        server.sendall("g1:1|g\n")
-        server.sendall("g1:50|g\n")
+        server.sendall(b"g1:1|g\n")
+        server.sendall(b"g1:50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -328,8 +332,8 @@ class TestIntegUDP(object):
     def test_gauges_delta(self, servers):
         "Tests adding gauges"
         _, server, output = servers
-        server.sendall("gd:+50|g\n")
-        server.sendall("gd:+50|g\n")
+        server.sendall(b"gd:+50|g\n")
+        server.sendall(b"gd:+50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -338,8 +342,8 @@ class TestIntegUDP(object):
     def test_gauges_delta_neg(self, servers):
         "Tests adding gauges"
         _, server, output = servers
-        server.sendall("gd:-50|g\n")
-        server.sendall("gd:-50|g\n")
+        server.sendall(b"gd:-50|g\n")
+        server.sendall(b"gd:-50|g\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -348,8 +352,8 @@ class TestIntegUDP(object):
     def test_bad_kv(self, servers):
         "Tests adding a bad value, followed by a valid kv pair"
         _, server, output = servers
-        server.sendall("this is junk data\n")
-        server.sendall("tubez:100|kv\n")
+        server.sendall(b"this is junk data\n")
+        server.sendall(b"tubez:100|kv\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -358,9 +362,9 @@ class TestIntegUDP(object):
     def test_counters(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("foobar:100|c\n")
-        server.sendall("foobar:200|c\n")
-        server.sendall("foobar:300|c\n")
+        server.sendall(b"foobar:100|c\n")
+        server.sendall(b"foobar:200|c\n")
+        server.sendall(b"foobar:300|c\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -370,9 +374,9 @@ class TestIntegUDP(object):
     def test_counters_signed(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("foobar:+100|c\n")
-        server.sendall("foobar:+200|c\n")
-        server.sendall("foobar:-50|c\n")
+        server.sendall(b"foobar:+100|c\n")
+        server.sendall(b"foobar:+200|c\n")
+        server.sendall(b"foobar:-50|c\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -382,9 +386,9 @@ class TestIntegUDP(object):
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("foobar:100|c|@0.1\n")
-        server.sendall("foobar:200|c|@0.1\n")
-        server.sendall("foobar:300|c|@0.1\n")
+        server.sendall(b"foobar:100|c|@0.1\n")
+        server.sendall(b"foobar:200|c|@0.1\n")
+        server.sendall(b"foobar:300|c|@0.1\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -394,8 +398,8 @@ class TestIntegUDP(object):
     def test_wrong_protocol_in_a_batch(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("foobar10c\nfoobar:10|c\nfoobar:10|c\n")
-        server.sendall("foobar:c\nfoobar:10|c\nfoobar:10|c\n")
+        server.sendall(b"foobar10c\nfoobar:10|c\nfoobar:10|c\n")
+        server.sendall(b"foobar:c\nfoobar:10|c\nfoobar:10|c\n")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -405,9 +409,9 @@ class TestIntegUDP(object):
     def test_counters_no_newlines(self, servers):
         "Tests adding counters without a trailing new line"
         _, server, output = servers
-        server.sendall("zip:100|c")
-        server.sendall("zip:200|c")
-        server.sendall("zip:300|c")
+        server.sendall(b"zip:100|c")
+        server.sendall(b"zip:200|c")
+        server.sendall(b"zip:300|c")
         wait_file(output)
         now = time.time()
         out = open(output).read()
@@ -417,9 +421,9 @@ class TestIntegUDP(object):
     def test_meters(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        msg = ""
-        for x in xrange(100):
-            msg += "noobs:%d|ms\n" % x
+        msg = b""
+        for x in range(100):
+            msg += b"noobs:%d|ms\n" % x
         server.sendall(msg)
         wait_file(output)
         out = open(output).read()
@@ -440,9 +444,9 @@ class TestIntegUDP(object):
     def test_sets(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
-        server.sendall("zip:foo|s\n")
-        server.sendall("zip:bar|s\n")
-        server.sendall("zip:baz|s\n")
+        server.sendall(b"zip:foo|s\n")
+        server.sendall(b"zip:bar|s\n")
+        server.sendall(b"zip:baz|s\n")
 
         wait_file(output)
         now = time.time()
@@ -461,11 +465,11 @@ class TestIntegBindAddress(object):
         port = %d
         udp_port = %s
         bind_address = %s\n'''
-        fh.write(textwrap.dedent(conf % (port, port, addr)))
+        fh.write(textwrap.dedent(conf % (port, port, addr)).encode("utf-8"))
         fh.flush()
 
         try:
-            p = subprocess.Popen(['./statsite', '-f', fh.name])
+            p = subprocess.Popen([STATSITE, '-f', fh.name])
             time.sleep(0.3)
             yield port
         finally:
@@ -475,7 +479,7 @@ class TestIntegBindAddress(object):
     def islistening(self, addr, port, command='statsite'):
         try:
             cmd = ['lsof', '-FnPc', '-nP', '-i', '@%s:%s' % (addr, port)]
-            out = subprocess.check_output(cmd)
+            out = subprocess.check_output(cmd).decode("utf-8")
         except subprocess.CalledProcessError:
             return False
 

--- a/integ/test_librato.py
+++ b/integ/test_librato.py
@@ -9,7 +9,7 @@ import tempfile
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
@@ -33,7 +33,7 @@ timers.request#tag1=value1,tag2=value2.p90|16.000000|1401577507\
     options.setdefault("write_to_legacy", False)
 
     f = tempfile.NamedTemporaryFile(delete=False)
-    f.write(build_librato_config(options))
+    f.write(build_librato_config(options).encode("utf-8"))
     f.close()
     librato = sinks.librato.LibratoStore(f.name)
     os.unlink(f.name)
@@ -57,7 +57,7 @@ token = 02ac4003c4fcd11bf9cee34e34263155dc7ba1906c322d167db6ab4b2cd2082b\
 
     if "host" in options:
         config += "\nhost = %s" % (options["host"])
-    
+
     if "write_to_legacy" in options:
         config += "\nwrite_to_legacy = %s" % (options["write_to_legacy"])
     else:
@@ -85,7 +85,7 @@ class TestLibratoLegacy(object):
             "min":          1017.0,
             "stddev_m2":     0.0
         }
-        
+
         assert expected_output == self.librato.gauges["query\tlocalhost"]
 
     def test_counts_send_as_gauges(self):
@@ -232,14 +232,14 @@ class TestLibrato(object):
         }]
 
         # No top level sources allowed here...
-        assert False == self.librato.measurements.has_key("source")
-        assert False == self.librato.tags.has_key("source")
+        assert "source" not in self.librato.measurements
+        assert "source" not in self.librato.tags
         assert expected_output == self.librato.measurements["requests.2xx"]
 
     def test_host_tag_autopopulated(self):
         # 'host' is automatically defaulted to `hostname` unless specified in the config
         self.librato = build_librato()
-        assert self.librato.tags.has_key("host")
+        assert "host" in self.librato.tags
 
     def test_source_from_config(self):
         # 'source' is defaulted to the config value
@@ -279,7 +279,7 @@ class TestLibrato(object):
         })
         m = self.librato.measurements["requests.2xx\tmyhost"][0]
         assert m['tags']['source'] == 'uid_123'
-    
+
     def test_measurements_with_tags_and_source(self):
         self.librato = build_librato({
             "statsite_output": "counts.requests.2xx#environment=stg|42|1401577507",
@@ -291,13 +291,12 @@ class TestLibrato(object):
             "value": 42,
             "tags": { "source": "myhost", "environment": "stg" }
         }]
-        
-        # This should still default to `hostname`
-        assert self.librato.tags.has_key("host")
-        # Top level source not allowed here
-        assert False == self.librato.measurements.has_key("source")
-        assert expected_output == self.librato.measurements["requests.2xx\tmyhost"]
 
+        # This should still default to `hostname`
+        assert "host" in self.librato.tags
+        # Top level source not allowed here
+        assert "source" not in self.librato.measurements
+        assert expected_output == self.librato.measurements["requests.2xx\tmyhost"]
 
     def test_metric_with_multiple_tagsets(self):
         data = """\
@@ -437,7 +436,7 @@ timers.foo.count|2|1401577507
         }]
 
         assert expected_output == self.librato.measurements["request"]
-        
+
     def test_measurements_with_period_in_tag_value_and_suffix(self):
         self.librato = build_librato({
             "statsite_output": "timers.tags_many_dots#tag1=value1,tag2=value.dotted.p90|16.000000|1401577507"
@@ -450,7 +449,7 @@ timers.foo.count|2|1401577507
         }]
 
         assert expected_output == self.librato.measurements["tags_many_dots.p90"]
-    
+
     def test_dual_write(self):
         self.librato = build_librato({
             "statsite_output": "counts.active_sessions|1.000000|1401577507",
@@ -496,6 +495,6 @@ timers.foo.count|2|1401577507
             "value":        16.0,
             "tags":         { "environment": "stg" }
         }]
-        
+
         assert {"host": "myhost" } == self.librato.tags
         assert expected_output == self.librato.measurements["requests.2xx"]

--- a/integ/test_stdin.py
+++ b/integ/test_stdin.py
@@ -13,11 +13,15 @@ import random
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+STATSITE = os.environ.get("STATSITE", "./statsite")
+
+
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -45,7 +49,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path], stdin=subprocess.PIPE)
+    proc = subprocess.Popen([STATSITE, '-f', config_path], stdin=subprocess.PIPE)
     proc.poll()
     assert proc.returncode is None
 
@@ -55,8 +59,8 @@ width=10
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
@@ -79,52 +83,57 @@ class TestInteg(object):
     def test_kv(self, servers):
         "Tests adding kv pairs"
         server, output = servers
-        server.write("tubez:100|kv\n")
+        server.write(b"tubez:100|kv\n")
+        server.flush()
 
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("kv.tubez|100.000000|%d\n" % now, "kv.tubez|100.000000|%d\n" % (now - 1))
 
     def test_gauges(self, servers):
         "Tests adding gauges"
         server, output = servers
-        server.write("g1:1|g\n")
-        server.write("g1:50|g\n")
+        server.write(b"g1:1|g\n")
+        server.write(b"g1:50|g\n")
+        server.flush()
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("gauges.g1|50.000000|%d\n" % now, "gauges.g1|50.000000|%d\n" % (now - 1))
 
     def test_gauges_delta(self, servers):
         "Tests adding gauges"
         server, output = servers
-        server.write("gd:+50|g\n")
-        server.write("gd:+50|g\n")
+        server.write(b"gd:+50|g\n")
+        server.write(b"gd:+50|g\n")
+        server.flush()
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("gauges.gd|100.000000|%d\n" % now, "gauges.gd|100.000000|%d\n" % (now - 1))
 
     def test_gauges_delta_neg(self, servers):
         "Tests adding gauges"
         server, output = servers
-        server.write("gd:-50|g\n")
-        server.write("gd:-50|g\n")
+        server.write(b"gd:-50|g\n")
+        server.write(b"gd:-50|g\n")
+        server.flush()
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("gauges.gd|-100.000000|%d\n" % now, "gauges.gd|-100.000000|%d\n" % (now - 1))
 
     def test_counters(self, servers):
         "Tests adding kv pairs"
         server, output = servers
-        server.write("foobar:100|c\n")
-        server.write("foobar:200|c\n")
-        server.write("foobar:300|c\n")
+        server.write(b"foobar:100|c\n")
+        server.write(b"foobar:200|c\n")
+        server.write(b"foobar:300|c\n")
+        server.flush()
 
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("counts.foobar|600.000000|%d\n" % (now),
                        "counts.foobar|600.000000|%d\n" % (now - 1))
@@ -132,12 +141,13 @@ class TestInteg(object):
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
         server, output = servers
-        server.write("foobar:100|c|@0.1\n")
-        server.write("foobar:200|c|@0.1\n")
-        server.write("foobar:300|c|@0.1\n")
+        server.write(b"foobar:100|c|@0.1\n")
+        server.write(b"foobar:200|c|@0.1\n")
+        server.write(b"foobar:300|c|@0.1\n")
+        server.flush()
 
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("counts.foobar|6000.000000|%d\n" % (now),
                        "counts.foobar|6000.000000|%d\n" % (now - 1))
@@ -146,9 +156,10 @@ class TestInteg(object):
         "Tests adding kv pairs"
         server, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += "noobs:%d|ms\n" % x
-        server.write(msg)
+        server.write(msg.encode("utf-8"))
+        server.flush()
 
         wait_file(output)
         out = open(output).read()
@@ -167,9 +178,10 @@ class TestInteg(object):
         "Tests adding keys with histograms"
         server, output = servers
         msg = ""
-        for x in xrange(100):
+        for x in range(100):
             msg += "has_hist.test:%d|ms\n" % x
-        server.write(msg)
+        server.write(msg.encode("utf-8"))
+        server.flush()
 
         wait_file(output)
         out = open(output).read()
@@ -187,12 +199,13 @@ class TestInteg(object):
     def test_sets(self, servers):
         "Tests adding kv pairs"
         server, output = servers
-        server.write("zip:foo|s\n")
-        server.write("zip:bar|s\n")
-        server.write("zip:baz|s\n")
+        server.write(b"zip:foo|s\n")
+        server.write(b"zip:bar|s\n")
+        server.write(b"zip:baz|s\n")
+        server.flush()
 
         wait_file(output)
-        now = time.time()
+        now = int(time.time())
         out = open(output).read()
         assert out in ("sets.zip|3|%d\n" % now, "sets.zip|3|%d\n" % (now - 1))
 

--- a/integ/test_timers_include.py
+++ b/integ/test_timers_include.py
@@ -11,11 +11,15 @@ import random
 try:
     import pytest
 except ImportError:
-    print >> sys.stderr, "Integ tests require pytests!"
+    sys.stderr.write("Integ tests require pytests!\n")
     sys.exit(1)
 
 
-def pytest_funcarg__servers(request):
+STATSITE = os.environ.get("STATSITE", "./statsite")
+
+
+@pytest.fixture
+def servers(request):
     "Returns a new APIHandler with a filter manager"
     # Create tmpdir and delete after
     tmpdir = tempfile.mkdtemp()
@@ -38,7 +42,7 @@ timers_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,SAMPLE_RATE
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc = subprocess.Popen([STATSITE, '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -48,22 +52,22 @@ timers_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,SAMPLE_RATE
             proc.kill()
             proc.wait()
             shutil.rmtree(tmpdir)
-        except:
-            print proc
+        except Exception:
+            print(proc)
             pass
     request.addfinalizer(cleanup)
 
     # Make a connection to the server
     connected = False
-    for x in xrange(3):
+    for x in range(3):
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             conn.settimeout(1)
             conn.connect(("localhost", port))
             connected = True
             break
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             time.sleep(0.5)
 
     # Die now
@@ -93,9 +97,9 @@ class TestInteg(object):
     def test_counters(self, servers):
         "Tests adding kv pairs"
         server, _, output = servers
-        server.sendall("foobar:100|ms\n")
-        server.sendall("foobar:200|ms\n")
-        server.sendall("foobar:300|ms\n")
+        server.sendall(b"foobar:100|ms\n")
+        server.sendall(b"foobar:200|ms\n")
+        server.sendall(b"foobar:300|ms\n")
 
         wait_file(output)
         out = open(output).read()
@@ -110,5 +114,3 @@ class TestInteg(object):
         assert "timers.foobar.median" not in out
         assert "timers.foobar.p50|200" in out
         assert "timers.foobar.sample_rate|3" in out
-
-

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,93 @@
+project(
+  'statsite', 'c',
+  version: '0.8.1',
+  license: 'BSD3',
+  meson_version: '>=1.3.0',
+  default_options: [
+    'b_lto=true',
+    'c_std=gnu99',
+  ],
+)
+
+conf_data = configuration_data()
+conf_data.set('VERSION', meson.project_version())
+
+cc = meson.get_compiler('c')
+
+add_project_arguments(
+  cc.get_supported_arguments('-fvisibility=hidden'),
+  language: 'c'
+)
+
+libstatsite = static_library(
+  'statsite',
+  [
+    'deps/ae/ae.c',
+    'deps/inih/inih.c',
+    'deps/murmurhash/MurmurHash3.c',
+    'src/ascii_parser.c',
+    'src/carbon.c',
+    'src/cm_quantile.c',
+    'src/config.c',
+    'src/conn_handler.c',
+    'src/counter.c',
+    'src/hashmap.c',
+    'src/heap.c',
+    'src/hll.c',
+    'src/hll_constants.c',
+    'src/metrics.c',
+    'src/networking.c',
+    'src/radix.c',
+    'src/set.c',
+    'src/streaming.c',
+    'src/timer.c',
+  ],
+  include_directories: include_directories(['src', 'deps/ae', 'deps/inih']),
+  install: false,
+)
+
+libstatsite_dep = declare_dependency(
+  link_with: libstatsite,
+  include_directories: include_directories('src'),
+  dependencies: [
+    cc.find_library('m', required : false),
+    cc.find_library('rt', required : false),
+    dependency('threads')
+  ],
+)
+
+statsite = executable(
+  'statsite',
+  'src/statsite.c',
+  dependencies: [libstatsite_dep],
+  install: true
+)
+
+configure_file(
+  input : 'buildconfig.h.in',
+  output : 'buildconfig.h',
+  configuration : conf_data
+)
+
+install_man('man/statsite.8')
+
+install_data(
+  'sinks/__init__.py',
+  'sinks/binary_sink.py',
+  'sinks/cloudwatch.sh',
+  'sinks/gmetric.py',
+  'sinks/graphite.py',
+  'sinks/http.py',
+  'sinks/influxdb.py',
+  'sinks/librato.py',
+  'sinks/opentsdb.js',
+  'sinks/statsite_json_sink.rb',
+  preserve_path: true,
+)
+
+install_data(
+  'statsite.conf.example',
+  install_dir: join_paths(get_option('sysconfdir'), 'statsite')
+)
+
+subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -91,3 +91,4 @@ install_data(
 )
 
 subdir('tests')
+subdir('integ')

--- a/sinks/influxdb.py
+++ b/sinks/influxdb.py
@@ -65,8 +65,8 @@ class InfluxDBStore(object):
         """
         Loads configuration from an INI format file.
         """
-        import ConfigParser
-        ini = ConfigParser.RawConfigParser()
+        from six.moves import configparser
+        ini = configparser.RawConfigParser()
         ini.read(cfg)
 
         sect = "influxdb"

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -5,10 +5,10 @@ import ast
 import sys
 import socket
 import logging
-import ConfigParser
+from six.moves import configparser
 import re
 import base64
-import urllib2
+from six.moves import urllib_request
 import json
 import os
 
@@ -69,7 +69,7 @@ class LibratoStore(object):
         self.flush_timeout_secs = 5
         self.gauges = {}
         self.measurements = {}
-        
+
         # Limit our payload sizes
         self.max_metrics_payload = 500
 
@@ -96,7 +96,7 @@ class LibratoStore(object):
 
         sect = "librato"
 
-        config = ConfigParser.RawConfigParser()
+        config = configparser.RawConfigParser()
         config.read(conffile)
 
         if not config.has_section(sect):
@@ -119,7 +119,7 @@ class LibratoStore(object):
             self.source = config.get(sect, 'source')
         else:
             self.source = None
-        
+
         if config.has_option(sect, 'host'):
             self.host = config.get(sect, 'host')
         else:
@@ -155,13 +155,13 @@ class LibratoStore(object):
             self.extended_counters = config.getboolean(sect, "extended_counters")
         else:
             self.extended_counters = False
-        
+
         # Check if we want to also send measurements to legacy Librato API
         if config.has_option(sect, "write_to_legacy"):
             self.write_to_legacy = config.getboolean(sect, "write_to_legacy")
         else:
             self.write_to_legacy = False
-        
+
         # Global Tags
         if config.has_option(sect, "tags"):
             self.tags = ast.literal_eval(config.get(sect, "tags"))
@@ -181,13 +181,13 @@ class LibratoStore(object):
 
     def sanitize(self, name):
         return self.sanitize_re.sub("_", name)
-    
+
     def parse_tags(self, name, multipart=False):
         # Find and parse the tags from the name using the syntax name#tag1=value,tag2=value
         s = name.split("#")
         tags = {}
         raw_tags = []
-        
+
         if len(s) > 1:
             name = s.pop(0)
             raw_tags = s.pop().split(",")
@@ -215,8 +215,8 @@ class LibratoStore(object):
                 tag_key, tag_value = raw_tag.split("=")
                 tags[tag_key] = tag_value
         return name, tags
-                
-        
+
+
 
     def add_measure(self, key, value, time):
         ts = int(time)
@@ -256,14 +256,14 @@ class LibratoStore(object):
         # Bail if skipping
         if name == None:
             return
-            
+
         # Add a metric prefix
         if self.prefix:
             name = "%s.%s" % (self.prefix, name)
 
         name = self.sanitize(name)
-        
-        # Add the hostname as a global tag. 
+
+        # Add the hostname as a global tag.
         self.tags['host'] = self.host
 
         if source:
@@ -340,7 +340,7 @@ class LibratoStore(object):
         """
         POST a payload to Librato.
         """
-        
+
         if legacy:
             body = json.dumps({ 'gauges' : m })
             url = "%s/v1/metrics" % (self.api)
@@ -348,11 +348,11 @@ class LibratoStore(object):
             global_tags = self.tags
             body = json.dumps({ 'measurements' : m, 'tags': global_tags })
             url = "%s/v1/measurements" % (self.api)
-                
-        req = urllib2.Request(url, body, headers)
+
+        req = urllib_request.Request(url, body, headers)
 
         try:
-            f = urllib2.urlopen(req, timeout = self.flush_timeout_secs)
+            f = urllib_request.urlopen(req, timeout = self.flush_timeout_secs)
             response = f.read()
             f.close()
             # The new tags API supports partial payload accept/reject
@@ -362,7 +362,7 @@ class LibratoStore(object):
                 # errors could be [], so check that prior to logging anything
                 if parsed_response['errors']:
                     self.logger.error(parsed_response)
-        except urllib2.HTTPError as error:
+        except urllib_request.HTTPError as error:
             body = error.read()
             self.logger.warning('Failed to send metrics to Librato: Code: %d. Response: %s' % \
                                 (error.code, body))
@@ -382,7 +382,7 @@ class LibratoStore(object):
         # Nothing to do
         if len(self.measurements) == 0:
             return
-    
+
         headers = {
             'Content-Type': 'application/json',
             'User-Agent': self.build_user_agent(),
@@ -392,7 +392,7 @@ class LibratoStore(object):
         tagged_metrics = []
         legacy_metrics = []
         count = 0
-        
+
         for v in self.measurements.values():
             for metric in v:
                 tagged_metrics.append(metric)
@@ -405,7 +405,7 @@ class LibratoStore(object):
 
         if count > 0:
             self.flush_payload(headers, tagged_metrics)
-        
+
         # If enabled, submit flush metrics to Librato's legacy API
         if self.write_to_legacy:
             if len(self.gauges) == 0:
@@ -423,7 +423,7 @@ class LibratoStore(object):
 
             if count > 0:
                 self.flush_payload(headers, legacy_metrics, True)
-        
+
 
     def build_basic_auth(self):
         base64string = base64.encodestring('%s:%s' % (self.email, self.token))
@@ -450,7 +450,7 @@ if __name__ == "__main__":
 
     # Get all the inputs
     metrics = sys.stdin.read()
-    
+
     # Flush
     librato.build(metrics.splitlines())
     librato.flush()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,18 @@
+check_dep = dependency('check')
+
+test_runner = executable(
+  'runner',
+  'runner.c',
+  c_args: ['-Wno-int-conversion'],
+  dependencies: [check_dep, libstatsite_dep],
+  install: false,
+)
+
+test(
+  'tests',
+  test_runner,
+  env: {
+    'CK_FORK': 'yes',
+    'CK_VERBOSITY': 'verbose',
+  }
+)


### PR DESCRIPTION
This pull request adds a Meson build system to statsite and updates the integration tests to be compatible with Python 3.

The existing autotools-based build system is not removed and remains fully supported.